### PR TITLE
feat: add web interface for YOLOv9 training

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ As regards streaming control, from keyboard,
 - ```Q```: exit the running window
 - ```R```: to reset object tracker (equivalent to re-count number of entire vehicles from that time)
 - ```P```: pause video
+
+### Web UI for YOLOv9 training
+To launch a simple interface for starting YOLOv9 training:
+
+```bash
+cd webapp
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+Open `http://localhost:8000` in your browser to configure and start training.

--- a/sync_with_minio.sh
+++ b/sync_with_minio.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+DATASET="$1"
+TARGET_DIR="datasets/$DATASET"
+mkdir -p "$TARGET_DIR"
+if command -v mc >/dev/null 2>&1; then
+  mc alias set local http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1 || true
+  mc cp --recursive "local/ivadatasets/$DATASET" "$TARGET_DIR" >/dev/null 2>&1 || true
+fi

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -1,0 +1,84 @@
+from fastapi import FastAPI, BackgroundTasks
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from pathlib import Path
+import subprocess
+
+app = FastAPI()
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+STATIC_DIR = BASE_DIR / "frontend"
+REPO_ROOT = BASE_DIR.parent
+TRAIN_SCRIPT = REPO_ROOT / "detectors" / "yolov9" / "train.py"
+SYNC_SCRIPT = REPO_ROOT / "sync_with_minio.sh"
+
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+@app.get("/")
+def root():
+    return FileResponse(STATIC_DIR / "index.html")
+
+class TrainRequest(BaseModel):
+    dataset: str
+    batch: int
+    img_size: int
+    model: str
+    epochs: int
+
+def list_datasets() -> list[str]:
+    try:
+        subprocess.run(
+            ["mc", "alias", "set", "local", "http://localhost:9000", "minioadmin", "minioadmin"],
+            check=True,
+            capture_output=True,
+        )
+        result = subprocess.run(
+            ["mc", "ls", "local/ivadatasets"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        datasets = []
+        for line in result.stdout.splitlines():
+            parts = line.strip().split()
+            if parts:
+                name = parts[-1].rstrip('/')
+                datasets.append(name)
+        return datasets
+    except Exception:
+        return []
+
+@app.get("/api/datasets")
+def get_datasets():
+    return {"datasets": list_datasets()}
+
+def run_training(req: TrainRequest):
+    dataset_yaml = REPO_ROOT / "datasets" / req.dataset / "data.yaml"
+    subprocess.run(["bash", str(SYNC_SCRIPT), req.dataset], check=False)
+    cfg = REPO_ROOT / "detectors" / "yolov9" / "models" / "detect" / f"yolov9-{req.model}.yaml"
+    name = f"yolov9-{req.model}-{req.dataset}"
+    cmd = [
+        "python",
+        str(TRAIN_SCRIPT),
+        "--batch",
+        str(req.batch),
+        "--img",
+        str(req.img_size),
+        "--cfg",
+        str(cfg),
+        "--name",
+        name,
+        "--epochs",
+        str(req.epochs),
+        "--data",
+        str(dataset_yaml),
+        "--weights",
+        "",
+    ]
+    subprocess.run(cmd)
+
+@app.post("/api/train")
+def train(req: TrainRequest, background_tasks: BackgroundTasks):
+    background_tasks.add_task(run_training, req)
+    return {"status": "started"}

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>YOLOv9 Trainer</title>
+  <style>
+    .card { border: 1px solid #ccc; padding: 8px; margin: 4px; display:inline-block; cursor:pointer; }
+  </style>
+</head>
+<body>
+  <h1>Available Datasets</h1>
+  <div id="datasets"></div>
+  <h2>Training Configuration</h2>
+  <form id="trainForm">
+    <label>Dataset: <input id="dataset" required /></label><br/>
+    <label>Batch Size: <input type="number" id="batch" value="16" /></label><br/>
+    <label>Image Size: <input type="number" id="img" value="640" /></label><br/>
+    <label>Model:
+      <select id="model">
+        <option value="m">yolov9-m</option>
+        <option value="c">yolov9-c</option>
+        <option value="t">yolov9-t</option>
+      </select>
+    </label><br/>
+    <label>Epochs: <input type="number" id="epochs" value="100" /></label><br/>
+    <button type="submit">Train</button>
+  </form>
+  <script>
+    async function loadDatasets() {
+      const res = await fetch('/api/datasets');
+      const data = await res.json();
+      const container = document.getElementById('datasets');
+      container.innerHTML = '';
+      data.datasets.forEach(ds => {
+        const div = document.createElement('div');
+        div.className = 'card';
+        div.textContent = ds;
+        div.onclick = () => document.getElementById('dataset').value = ds;
+        container.appendChild(div);
+      });
+    }
+    document.getElementById('trainForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const payload = {
+        dataset: document.getElementById('dataset').value,
+        batch: parseInt(document.getElementById('batch').value),
+        img_size: parseInt(document.getElementById('img').value),
+        model: document.getElementById('model').value,
+        epochs: parseInt(document.getElementById('epochs').value)
+      };
+      await fetch('/api/train', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+      });
+      alert('Training started');
+    });
+    window.onload = loadDatasets;
+  </script>
+</body>
+</html>

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- add FastAPI backend and HTML frontend to start YOLOv9 training
- list datasets from MinIO and configure batch size, image size, model, and epochs
- include script to sync datasets from MinIO and update README

## Testing
- `python -m py_compile webapp/backend/main.py`
- `bash -n sync_with_minio.sh`
- `pytest` *(fails: ImportError: libGL.so.1 and SyntaxError in test_ocr.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894274f298c832193a61d09fbccd0c1