### PR TITLE
feat: add web interface for YOLOv9 training

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ As regards streaming control, from keyboard,
 - ```Q```: exit the running window
 - ```R```: to reset object tracker (equivalent to re-count number of entire vehicles from that time)
 - ```P```: pause video
+
+### TonAI Computer Vision Hub
+Launch a modern interface for starting YOLOv9 training with live progress updates:
+
+```bash
+cd webapp
+pip install -r requirements.txt
+uvicorn backend.main:app --reload
+```
+
+Open `http://localhost:8000` in your browser to configure the run, select datasets, and watch training progress.

--- a/sync_with_minio.sh
+++ b/sync_with_minio.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+DATASET="$1"
+TARGET_DIR="datasets/$DATASET"
+mkdir -p "$TARGET_DIR"
+if command -v mc >/dev/null 2>&1; then
+  mc alias set local http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1 || true
+  mc cp --recursive "local/ivadatasets/$DATASET" "$TARGET_DIR" >/dev/null 2>&1 || true
+fi

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -1,0 +1,120 @@
+from fastapi import FastAPI, BackgroundTasks
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from pathlib import Path
+import subprocess
+import re
+from threading import Lock
+
+app = FastAPI()
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+STATIC_DIR = BASE_DIR / "frontend"
+REPO_ROOT = BASE_DIR.parent
+TRAIN_SCRIPT = REPO_ROOT / "detectors" / "yolov9" / "train.py"
+SYNC_SCRIPT = REPO_ROOT / "sync_with_minio.sh"
+
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+@app.get("/")
+def root():
+    return FileResponse(STATIC_DIR / "index.html")
+
+class TrainRequest(BaseModel):
+    dataset: str
+    batch: int
+    img_size: int
+    model: str
+    epochs: int
+
+def list_datasets() -> list[str]:
+    try:
+        subprocess.run(
+            ["mc", "alias", "set", "local", "http://localhost:9000", "minioadmin", "minioadmin"],
+            check=True,
+            capture_output=True,
+        )
+        result = subprocess.run(
+            ["mc", "ls", "local/ivadatasets"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        datasets = []
+        for line in result.stdout.splitlines():
+            parts = line.strip().split()
+            if parts:
+                name = parts[-1].rstrip('/')
+                datasets.append(name)
+        return datasets
+    except Exception:
+        return []
+
+@app.get("/api/datasets")
+def get_datasets():
+    return {"datasets": list_datasets()}
+
+
+training_progress = 0
+training_running = False
+progress_lock = Lock()
+
+
+def set_progress(value: int, running: bool | None = None):
+    global training_progress, training_running
+    with progress_lock:
+        training_progress = value
+        if running is not None:
+            training_running = running
+
+
+@app.get("/api/progress")
+def get_progress():
+    with progress_lock:
+        return {"progress": training_progress, "running": training_running}
+
+def run_training(req: TrainRequest):
+    dataset_yaml = REPO_ROOT / "datasets" / req.dataset / "data.yaml"
+    subprocess.run(["bash", str(SYNC_SCRIPT), req.dataset], check=False)
+    cfg = REPO_ROOT / "detectors" / "yolov9" / "models" / "detect" / f"yolov9-{req.model}.yaml"
+    name = f"yolov9-{req.model}-{req.dataset}"
+    cmd = [
+        "python",
+        str(TRAIN_SCRIPT),
+        "--batch",
+        str(req.batch),
+        "--img",
+        str(req.img_size),
+        "--cfg",
+        str(cfg),
+        "--name",
+        name,
+        "--epochs",
+        str(req.epochs),
+        "--data",
+        str(dataset_yaml),
+        "--weights",
+        "",
+    ]
+    set_progress(0, True)
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    for line in proc.stdout:
+        match = re.search(r"(\d+)/(\d+)", line)
+        if match:
+            cur = int(match.group(1))
+            total = int(match.group(2))
+            set_progress(int(cur / total * 100))
+    proc.wait()
+    set_progress(100, False)
+
+@app.post("/api/train")
+def train(req: TrainRequest, background_tasks: BackgroundTasks):
+    background_tasks.add_task(run_training, req)
+    return {"status": "started"}

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>TonAI Computer Vision Hub</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 min-h-screen p-4">
+  <h1 class="text-3xl font-bold mb-6 text-center">TonAI Computer Vision Hub</h1>
+
+  <section>
+    <h2 class="text-xl font-semibold mb-2">Available Datasets</h2>
+    <div id="datasets" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+  </section>
+
+  <section class="mt-8">
+    <h2 class="text-xl font-semibold mb-2">Training Configuration</h2>
+    <form id="trainForm" class="space-y-4 max-w-md">
+      <div>
+        <label class="block text-sm font-medium">Dataset</label>
+        <input id="dataset" required class="mt-1 w-full border rounded p-2" />
+      </div>
+      <div class="flex gap-4">
+        <div class="flex-1">
+          <label class="block text-sm font-medium">Batch Size</label>
+          <input type="number" id="batch" value="16" class="mt-1 w-full border rounded p-2" />
+        </div>
+        <div class="flex-1">
+          <label class="block text-sm font-medium">Image Size</label>
+          <input type="number" id="img" value="640" class="mt-1 w-full border rounded p-2" />
+        </div>
+      </div>
+      <div class="flex gap-4">
+        <div class="flex-1">
+          <label class="block text-sm font-medium">Model</label>
+          <select id="model" class="mt-1 w-full border rounded p-2">
+            <option value="m">yolov9-m</option>
+            <option value="c">yolov9-c</option>
+            <option value="t">yolov9-t</option>
+          </select>
+        </div>
+        <div class="flex-1">
+          <label class="block text-sm font-medium">Epochs</label>
+          <input type="number" id="epochs" value="100" class="mt-1 w-full border rounded p-2" />
+        </div>
+      </div>
+      <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Train</button>
+    </form>
+
+    <div id="progressSection" class="mt-6 hidden max-w-md">
+      <div class="w-full bg-gray-200 rounded-full h-4">
+        <div id="progressBar" class="bg-blue-600 h-4 rounded-full" style="width: 0%"></div>
+      </div>
+      <p id="progressText" class="text-sm mt-1 text-gray-700">0%</p>
+    </div>
+  </section>
+
+  <script>
+    async function loadDatasets() {
+      const res = await fetch('/api/datasets');
+      const data = await res.json();
+      const container = document.getElementById('datasets');
+      container.innerHTML = '';
+      data.datasets.forEach(ds => {
+        const div = document.createElement('div');
+        div.className = 'p-4 border rounded shadow hover:bg-gray-100 cursor-pointer';
+        div.textContent = ds;
+        div.onclick = () => document.getElementById('dataset').value = ds;
+        container.appendChild(div);
+      });
+    }
+
+    let progressTimer;
+    async function pollProgress() {
+      const res = await fetch('/api/progress');
+      const data = await res.json();
+      document.getElementById('progressBar').style.width = data.progress + '%';
+      document.getElementById('progressText').innerText = data.progress + '%';
+      if (!data.running || data.progress >= 100) {
+        clearInterval(progressTimer);
+      }
+    }
+
+    document.getElementById('trainForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const payload = {
+        dataset: document.getElementById('dataset').value,
+        batch: parseInt(document.getElementById('batch').value),
+        img_size: parseInt(document.getElementById('img').value),
+        model: document.getElementById('model').value,
+        epochs: parseInt(document.getElementById('epochs').value)
+      };
+      await fetch('/api/train', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+      });
+      document.getElementById('progressSection').classList.remove('hidden');
+      document.getElementById('progressBar').style.width = '0%';
+      document.getElementById('progressText').innerText = '0%';
+      progressTimer = setInterval(pollProgress, 1000);
+    });
+
+    window.onload = loadDatasets;
+  </script>
+</body>
+</html>
+

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic


### PR DESCRIPTION
## Summary
- track YOLOv9 training progress and expose `/api/progress`
- rebuild frontend as Tailwind-based **TonAI Computer Vision Hub** with dataset cards and progress bar
- document the modern training UI in the README

## Testing
- `python -m py_compile webapp/backend/main.py`
- `bash -n sync_with_minio.sh`
- `pytest` *(fails: SyntaxError in test_ocr.py)*

------
https://chatgpt.com/codex/tasks/task_e_6894274f298c832193a61d09fbccd0c1