### PR TITLE
Add Projects page with ALPR demo using TonAI OCR

### DIFF
--- a/test_alpr.py
+++ b/test_alpr.py
@@ -63,7 +63,7 @@ class ALPR:
         vehicle_detection = self.vehicle_detector(
             image,
             verbose=False,
-            device=opts.device,
+            device=self.opts.device,
             imgsz=640,
             conf=self.opts.vconf)[0]
         vehicle_boxes = vehicle_detection.boxes

--- a/test_ocr.py
+++ b/test_ocr.py
@@ -4,12 +4,10 @@ import time
 import re
 import tqdm
 import json
-from ppocr_onnx import DetAndRecONNXPipeline
+from ton_ocr import TonOCRPipeline
 from utils.utils import check_legit_plate, check_image_size
 
-PLATE_READER = DetAndRecONNXPipeline(
-    text_det_onnx_model="weights/ppocrv4/ch_PP-OCRv4_det_infer.onnx",
-    text_rec_onnx_model="updated_model_dyn.onnx")
+PLATE_READER = TonOCRPipeline()
 
 
 def extract_plate_info(plate_image, conf_thres):
@@ -22,7 +20,7 @@ def extract_plate_info(plate_image, conf_thres):
     Returns:
         (string, float): OCR result and average confidence
     """
-    results = PLATE_READER.detect_and_ocr(plate_image)``
+    results = PLATE_READER.predict(plate_image)
     if len(results) > 0:
         plate_info = ''
         conf = []

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -12,10 +12,11 @@
       <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
       <h1 class="text-2xl font-bold text-white">TonAI</h1>
     </div>
-    <a href="#/home" id="home-link" class="active">Home</a>
-    <a href="#/training" id="training-link">Training</a>
-  </div>
-  <div class="main-content">
+      <a href="#/home" id="home-link" class="active">Home</a>
+      <a href="#/training" id="training-link">Training</a>
+      <a href="#/projects" id="projects-link">Projects</a>
+    </div>
+    <div class="main-content">
     <div id="home-page" class="flex justify-center items-center">
       <div class="ambient-light"></div>
       <div class="content">
@@ -26,7 +27,7 @@
         </div>
       </div>
     </div>
-    <div id="training-page" style="display: none;">
+      <div id="training-page" style="display: none;">
       <h1 class="text-3xl font-bold mb-6 text-center">TonAI Computer Vision Hub</h1>
 
       <section>
@@ -74,10 +75,24 @@
           </div>
           <p id="progressText" class="text-sm mt-1 text-gray-700">0%</p>
         </div>
-      </section>
+        </section>
+      </div>
+      <div id="projects-page" style="display: none;">
+        <h1 class="text-3xl font-bold mb-6 text-center">Projects</h1>
+        <div class="flex justify-center gap-4 mb-6">
+          <button id="alpr-btn" class="bg-blue-600 text-white px-4 py-2 rounded">ALPR</button>
+          <a href="https://huggingface.co/spaces/tungedng2710/TonAI-OCR" target="_blank" class="bg-green-600 text-white px-4 py-2 rounded flex items-center">OCR Document</a>
+        </div>
+        <div id="alpr-demo" class="hidden flex flex-col items-center">
+          <form id="alpr-form" class="mb-4">
+            <input type="file" id="alpr-image" accept="image/*" class="mb-2" required />
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Predict</button>
+          </form>
+          <img id="alpr-result" class="max-w-full" />
+        </div>
+      </div>
     </div>
-  </div>
-  <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -1,32 +1,66 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const homeLink = document.getElementById('home-link');
-  const trainingLink = document.getElementById('training-link');
-  const homePage = document.getElementById('home-page');
-  const trainingPage = document.getElementById('training-page');
-  const startBtn = document.getElementById('start-btn');
+  document.addEventListener('DOMContentLoaded', () => {
+    const homeLink = document.getElementById('home-link');
+    const trainingLink = document.getElementById('training-link');
+    const projectsLink = document.getElementById('projects-link');
+    const homePage = document.getElementById('home-page');
+    const trainingPage = document.getElementById('training-page');
+    const projectsPage = document.getElementById('projects-page');
+    const startBtn = document.getElementById('start-btn');
+    const alprBtn = document.getElementById('alpr-btn');
+    const alprDemo = document.getElementById('alpr-demo');
+    const alprForm = document.getElementById('alpr-form');
+    const alprResult = document.getElementById('alpr-result');
 
-  function handleRouteChange() {
-    const hash = window.location.hash;
-    if (hash === '#/training') {
-      homePage.style.display = 'none';
-      trainingPage.style.display = 'block';
-      homeLink.classList.remove('active');
-      trainingLink.classList.add('active');
-    } else {
-      homePage.style.display = 'flex';
-      trainingPage.style.display = 'none';
-      homeLink.classList.add('active');
-      trainingLink.classList.remove('active');
+    function handleRouteChange() {
+      const hash = window.location.hash;
+      if (hash === '#/training') {
+        homePage.style.display = 'none';
+        trainingPage.style.display = 'block';
+        projectsPage.style.display = 'none';
+        homeLink.classList.remove('active');
+        trainingLink.classList.add('active');
+        projectsLink.classList.remove('active');
+      } else if (hash === '#/projects') {
+        homePage.style.display = 'none';
+        trainingPage.style.display = 'none';
+        projectsPage.style.display = 'block';
+        homeLink.classList.remove('active');
+        trainingLink.classList.remove('active');
+        projectsLink.classList.add('active');
+        alprDemo.classList.add('hidden');
+        alprResult.src = '';
+      } else {
+        homePage.style.display = 'flex';
+        trainingPage.style.display = 'none';
+        projectsPage.style.display = 'none';
+        homeLink.classList.add('active');
+        trainingLink.classList.remove('active');
+        projectsLink.classList.remove('active');
+      }
     }
-  }
 
   window.addEventListener('hashchange', handleRouteChange);
   // Handle initial page load
   handleRouteChange();
 
-  startBtn.addEventListener('click', () => {
-    window.location.hash = '#/training';
-  });
+    startBtn.addEventListener('click', () => {
+      window.location.hash = '#/training';
+    });
+
+    alprBtn.addEventListener('click', () => {
+      alprDemo.classList.remove('hidden');
+    });
+
+    alprForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const file = document.getElementById('alpr-image').files[0];
+      if (!file) return;
+      const formData = new FormData();
+      formData.append('file', file);
+      const res = await fetch('/api/alpr', { method: 'POST', body: formData });
+      const blob = await res.blob();
+      alprResult.src = URL.createObjectURL(blob);
+    });
 
   async function loadDatasets() {
     const res = await fetch('/api/datasets');

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,3 +1,7 @@
 fastapi
 uvicorn
 pydantic
+ultralytics
+opencv-python-headless
+numpy
+ton-ocr


### PR DESCRIPTION
## Summary
- integrate TonAI-OCR into plate OCR pipeline
- add Projects page with ALPR demo and OCR Document link
- expose `/api/alpr` FastAPI endpoint and JS client for image upload

## Testing
- `python -m py_compile test_ocr.py webapp/backend/main.py test_alpr.py`
- `node --check webapp/frontend/script.js`


------
https://chatgpt.com/codex/tasks/task_e_689469a7d600832187e198129e459da0