### PR TITLE
feat: add dataset browser with minio config

### DIFF
--- a/minio_config.json
+++ b/minio_config.json
@@ -1,0 +1,6 @@
+{
+  "endpoint": "http://localhost:9000",
+  "access_key": "minioadmin",
+  "secret_key": "minioadmin",
+  "bucket": "ivadatasets"
+}

--- a/sync_with_minio.sh
+++ b/sync_with_minio.sh
@@ -2,8 +2,15 @@
 set -e
 DATASET="$1"
 TARGET_DIR="datasets/$DATASET"
+CONFIG_FILE="minio_config.json"
+
+ENDPOINT=$(jq -r '.endpoint' "$CONFIG_FILE")
+ACCESS_KEY=$(jq -r '.access_key' "$CONFIG_FILE")
+SECRET_KEY=$(jq -r '.secret_key' "$CONFIG_FILE")
+BUCKET=$(jq -r '.bucket' "$CONFIG_FILE")
+
 mkdir -p "$TARGET_DIR"
 if command -v mc >/dev/null 2>&1; then
-  mc alias set local http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1 || true
-  mc cp --recursive "local/ivadatasets/$DATASET" "$TARGET_DIR" >/dev/null 2>&1 || true
+  mc alias set local "$ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY" >/dev/null 2>&1 || true
+  mc cp --recursive "local/$BUCKET/$DATASET" "$TARGET_DIR" >/dev/null 2>&1 || true
 fi

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -14,6 +14,7 @@
     </div>
       <a href="#/home" id="home-link" class="active">Home</a>
       <a href="#/training" id="training-link">Training</a>
+      <a href="#/datasets" id="datasets-link">Datasets</a>
       <a href="#/projects" id="projects-link">Projects</a>
     </div>
     <div class="main-content">
@@ -75,7 +76,11 @@
           </div>
           <p id="progressText" class="text-sm mt-1 text-gray-700">0%</p>
         </div>
-        </section>
+      </section>
+      </div>
+      <div id="datasets-page" style="display: none;">
+        <h1 class="text-3xl font-bold mb-6 text-center">Datasets</h1>
+        <div id="dataset-cards" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
       </div>
       <div id="projects-page" style="display: none;">
         <h1 class="text-5xl font-bold mb-10 text-center title">Projects</h1>
@@ -85,7 +90,18 @@
         </div>
       </div>
     </div>
+    <div id="dataset-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+      <div class="bg-white text-black p-6 rounded-lg w-80">
+        <div class="flex justify-between items-center mb-4">
+          <h2 id="modal-title" class="text-xl font-bold"></h2>
+          <button id="modal-close" class="text-gray-500">&times;</button>
+        </div>
+        <canvas id="datasetChart" class="mb-4"></canvas>
+        <p id="dataset-counts" class="text-center"></p>
+      </div>
+    </div>
     <script src="https://cdn.tailwindcss.com"></script>
-  <script src="script.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -1,10 +1,14 @@
   document.addEventListener('DOMContentLoaded', () => {
     const homeLink = document.getElementById('home-link');
     const trainingLink = document.getElementById('training-link');
+    const datasetsLink = document.getElementById('datasets-link');
     const projectsLink = document.getElementById('projects-link');
     const homePage = document.getElementById('home-page');
     const trainingPage = document.getElementById('training-page');
+    const datasetsPage = document.getElementById('datasets-page');
     const projectsPage = document.getElementById('projects-page');
+    const datasetModal = document.getElementById('dataset-modal');
+    const modalClose = document.getElementById('modal-close');
     const startBtn = document.getElementById('start-btn');
 
     function handleRouteChange() {
@@ -12,23 +16,39 @@
       if (hash === '#/training') {
         homePage.style.display = 'none';
         trainingPage.style.display = 'block';
+        datasetsPage.style.display = 'none';
         projectsPage.style.display = 'none';
         homeLink.classList.remove('active');
         trainingLink.classList.add('active');
+        datasetsLink.classList.remove('active');
         projectsLink.classList.remove('active');
+      } else if (hash === '#/datasets') {
+        homePage.style.display = 'none';
+        trainingPage.style.display = 'none';
+        datasetsPage.style.display = 'block';
+        projectsPage.style.display = 'none';
+        homeLink.classList.remove('active');
+        trainingLink.classList.remove('active');
+        datasetsLink.classList.add('active');
+        projectsLink.classList.remove('active');
+        loadDatasetCards();
       } else if (hash === '#/projects') {
         homePage.style.display = 'none';
         trainingPage.style.display = 'none';
+        datasetsPage.style.display = 'none';
         projectsPage.style.display = 'block';
         homeLink.classList.remove('active');
         trainingLink.classList.remove('active');
+        datasetsLink.classList.remove('active');
         projectsLink.classList.add('active');
       } else {
         homePage.style.display = 'flex';
         trainingPage.style.display = 'none';
+        datasetsPage.style.display = 'none';
         projectsPage.style.display = 'none';
         homeLink.classList.add('active');
         trainingLink.classList.remove('active');
+        datasetsLink.classList.remove('active');
         projectsLink.classList.remove('active');
       }
     }
@@ -50,17 +70,57 @@
     data.datasets.forEach(ds => {
       const div = document.createElement('div');
       div.className = 'p-4 border rounded shadow hover:bg-gray-100 cursor-pointer';
-      
+
       const title = document.createElement('h3');
       title.className = 'font-bold';
       title.textContent = ds;
       div.appendChild(title);
 
       div.onclick = () => document.getElementById('dataset').value = ds;
-      
+
       container.appendChild(div);
     });
   }
+
+  async function loadDatasetCards() {
+    const res = await fetch('/api/datasets');
+    const data = await res.json();
+    const container = document.getElementById('dataset-cards');
+    container.innerHTML = '';
+
+    data.datasets.forEach(ds => {
+      const div = document.createElement('div');
+      div.className = 'dataset-card';
+      div.textContent = ds;
+      div.onclick = () => showDatasetStats(ds);
+      container.appendChild(div);
+    });
+  }
+
+  let chart;
+  async function showDatasetStats(name) {
+    const res = await fetch(`/api/datasets/${name}/stats`);
+    const data = await res.json();
+    document.getElementById('modal-title').innerText = name;
+    document.getElementById('dataset-counts').innerText = `Train: ${data.train}, Val: ${data.val}, Test: ${data.test}`;
+    const ctx = document.getElementById('datasetChart').getContext('2d');
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: ['Train', 'Val', 'Test'],
+        datasets: [{
+          data: [data.train, data.val, data.test],
+          backgroundColor: ['#3b82f6', '#10b981', '#f59e0b']
+        }]
+      }
+    });
+    datasetModal.classList.remove('hidden');
+  }
+
+  modalClose.addEventListener('click', () => {
+    datasetModal.classList.add('hidden');
+  });
 
   let progressTimer;
   async function pollProgress() {

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -178,3 +178,34 @@ body {
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
 }
 
+#datasets-page {
+  background-color: #f3f4f6;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+#dataset-cards {
+  display: grid;
+  gap: 1rem;
+}
+
+.dataset-card {
+  background: rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(5px);
+  padding: 20px;
+  text-align: center;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+.dataset-card:hover {
+  background: rgba(255, 255, 255, 0.4);
+}
+
+#dataset-modal canvas {
+  max-width: 100%;
+}
+


### PR DESCRIPTION
## Summary
- add dedicated Datasets page with MinIO-backed dataset cards and stats modal
- centralize MinIO credentials in `minio_config.json`
- expose dataset statistics API and updated sync script

## Testing
- `pytest` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_689477fa02448321954106b312a67f39