### PR TITLE
feat: add dataset browser with minio config

### DIFF
--- a/minio_config.json
+++ b/minio_config.json
@@ -1,0 +1,6 @@
+{
+  "endpoint": "http://localhost:9000",
+  "access_key": "minioadmin",
+  "secret_key": "minioadmin",
+  "bucket": "ivadatasets"
+}

--- a/sync_with_minio.sh
+++ b/sync_with_minio.sh
@@ -2,8 +2,15 @@
 set -e
 DATASET="$1"
 TARGET_DIR="datasets/$DATASET"
+CONFIG_FILE="minio_config.json"
+
+ENDPOINT=$(jq -r '.endpoint' "$CONFIG_FILE")
+ACCESS_KEY=$(jq -r '.access_key' "$CONFIG_FILE")
+SECRET_KEY=$(jq -r '.secret_key' "$CONFIG_FILE")
+BUCKET=$(jq -r '.bucket' "$CONFIG_FILE")
+
 mkdir -p "$TARGET_DIR"
 if command -v mc >/dev/null 2>&1; then
-  mc alias set local http://localhost:9000 minioadmin minioadmin >/dev/null 2>&1 || true
-  mc cp --recursive "local/ivadatasets/$DATASET" "$TARGET_DIR" >/dev/null 2>&1 || true
+  mc alias set local "$ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY" >/dev/null 2>&1 || true
+  mc cp --recursive "local/$BUCKET/$DATASET" "$TARGET_DIR" >/dev/null 2>&1 || true
 fi

--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -8,6 +8,7 @@ import re
 from threading import Lock
 import numpy as np
 import cv2
+import json
 from types import SimpleNamespace
 from test_alpr import ALPR
 
@@ -18,6 +19,13 @@ STATIC_DIR = BASE_DIR / "frontend"
 REPO_ROOT = BASE_DIR.parent
 TRAIN_SCRIPT = REPO_ROOT / "detectors" / "yolov9" / "train.py"
 SYNC_SCRIPT = REPO_ROOT / "sync_with_minio.sh"
+
+with open(REPO_ROOT / "minio_config.json") as f:
+    MINIO_CFG = json.load(f)
+MINIO_ENDPOINT = MINIO_CFG["endpoint"]
+MINIO_ACCESS_KEY = MINIO_CFG["access_key"]
+MINIO_SECRET_KEY = MINIO_CFG["secret_key"]
+MINIO_BUCKET = MINIO_CFG["bucket"]
 
 # Initialize ALPR model
 opts = SimpleNamespace(
@@ -40,12 +48,12 @@ class TrainRequest(BaseModel):
 def list_datasets() -> list[str]:
     try:
         subprocess.run(
-            ["/usr/local/bin/mc", "alias", "set", "local", "http://localhost:9000", "minioadmin", "minioadmin"],
+            ["/usr/local/bin/mc", "alias", "set", "local", MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY],
             check=True,
             capture_output=True,
         )
         result = subprocess.run(
-            ["/usr/local/bin/mc", "ls", "local/ivadatasets"],
+            ["/usr/local/bin/mc", "ls", f"local/{MINIO_BUCKET}"],
             check=True,
             capture_output=True,
             text=True,
@@ -64,9 +72,37 @@ def list_datasets() -> list[str]:
 def get_datasets():
     return {"datasets": list_datasets()}
 
-@app.get("/api/datasets/{dataset_name}/samples")
-def get_dataset_samples(dataset_name: str):
-    return {"images": []}
+def dataset_stats(dataset_name: str) -> dict:
+    try:
+        subprocess.run(
+            ["/usr/local/bin/mc", "alias", "set", "local", MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY],
+            check=True,
+            capture_output=True,
+        )
+        stats: dict[str, int | list[str]] = {}
+        for split in ["train", "val", "test"]:
+            result = subprocess.run(
+                ["/usr/local/bin/mc", "ls", f"local/{MINIO_BUCKET}/{dataset_name}/{split}/images"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            lines = [line for line in result.stdout.splitlines() if line.strip()]
+            stats[split] = len(lines)
+            if split == "train":
+                samples = [l.split()[-1] for l in lines][:12]
+                stats["samples"] = [
+                    f"{MINIO_ENDPOINT}/{MINIO_BUCKET}/{dataset_name}/train/images/{s}"
+                    for s in samples
+                ]
+        return stats
+    except Exception:
+        return {"train": 0, "val": 0, "test": 0, "samples": []}
+
+
+@app.get("/api/datasets/{dataset_name}/stats")
+def get_dataset_stats(dataset_name: str):
+    return dataset_stats(dataset_name)
 
 
 training_progress = 0

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -14,6 +14,7 @@
     </div>
       <a href="#/home" id="home-link" class="active">Home</a>
       <a href="#/training" id="training-link">Training</a>
+      <a href="#/datasets" id="datasets-link">Datasets</a>
       <a href="#/projects" id="projects-link">Projects</a>
     </div>
     <div class="main-content">
@@ -75,7 +76,11 @@
           </div>
           <p id="progressText" class="text-sm mt-1 text-gray-700">0%</p>
         </div>
-        </section>
+      </section>
+      </div>
+      <div id="datasets-page" style="display: none;">
+        <h1 class="text-3xl font-bold mb-6 text-center">Datasets</h1>
+        <div id="dataset-cards" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
       </div>
       <div id="projects-page" style="display: none;">
         <h1 class="text-5xl font-bold mb-10 text-center title">Projects</h1>
@@ -85,7 +90,19 @@
         </div>
       </div>
     </div>
+    <div id="dataset-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+        <div class="bg-white text-black p-6 rounded-lg w-80">
+        <div class="flex justify-between items-center mb-4">
+          <h2 id="modal-title" class="text-xl font-bold"></h2>
+          <button id="modal-close" class="text-gray-500">&times;</button>
+        </div>
+          <canvas id="datasetChart" class="mb-4"></canvas>
+          <div id="sample-images" class="grid grid-cols-3 gap-2 mb-4"></div>
+          <p id="dataset-counts" class="text-center"></p>
+        </div>
+      </div>
     <script src="https://cdn.tailwindcss.com"></script>
-  <script src="script.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Poppins:wght@500;600&display=swap');
 
 html {
   box-sizing: border-box;
@@ -176,5 +176,42 @@ body {
   background-color: #374151;
   transform: translateY(-5px);
   box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
+}
+
+#datasets-page {
+  background-color: #f3f4f6;
+  color: #333;
+  padding: 20px;
+  border-radius: 8px;
+}
+
+#dataset-cards {
+  display: grid;
+  gap: 1rem;
+}
+
+.dataset-card {
+  font-family: 'Poppins', sans-serif;
+  font-weight: 600;
+  font-size: 1.125rem;
+  color: #1f2937;
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(10px);
+  padding: 20px;
+  text-align: center;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, background 0.3s;
+}
+
+.dataset-card:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.25);
+}
+
+#dataset-modal canvas {
+  max-width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- add dedicated Datasets page with MinIO-backed dataset cards and stats modal
- centralize MinIO credentials in `minio_config.json`
- expose dataset statistics API and updated sync script
- show sample images in dataset stats popup and polish dataset card styling

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689477fa02448321954106b312a67f39