### PR TITLE
feat(webapp): add sidebar toggle and GitHub link

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -7,8 +7,9 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <button id="toggle-sidebar" class="toggle-btn">☰</button>
   <div class="sidebar">
-        <div class="flex items-center justify-center my-4">
+    <div class="flex items-center my-4">
       <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
       <h1 class="text-2xl font-bold text-white">TonAI</h1>
     </div>
@@ -16,6 +17,7 @@
       <a href="#/training" id="training-link">Training</a>
       <a href="#/datasets" id="datasets-link">Datasets</a>
       <a href="#/projects" id="projects-link">Projects</a>
+      <a href="https://github.com/tungedng2710/license-plate-recognition" target="_blank">GitHub</a>
     </div>
     <div class="main-content">
     <div id="home-page" class="flex justify-center items-center">

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -10,6 +10,15 @@
     const datasetModal = document.getElementById('dataset-modal');
     const modalClose = document.getElementById('modal-close');
     const startBtn = document.getElementById('start-btn');
+    const toggleBtn = document.getElementById('toggle-sidebar');
+    const sidebar = document.querySelector('.sidebar');
+
+    toggleBtn.style.left = '210px';
+
+    toggleBtn.addEventListener('click', () => {
+      const isHidden = sidebar.classList.toggle('hidden');
+      toggleBtn.style.left = isHidden ? '10px' : '210px';
+    });
 
     function handleRouteChange() {
       const hash = window.location.hash;

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -18,6 +18,19 @@ body {
   height: 100%;
 }
 
+.toggle-btn {
+  position: fixed;
+  top: 10px;
+  left: 210px;
+  background-color: #1f2937;
+  color: white;
+  border: none;
+  padding: 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  z-index: 1000;
+}
+
 .sidebar {
   width: 200px;
   background-color: #1f2937;


### PR DESCRIPTION
## Summary
- allow toggling the sidebar and add a GitHub shortcut
- align TonAI logo left and include a GitHub link in the sidebar
- reposition sidebar toggle to prevent it overlaying the logo or main content

## Testing
- `npm test` *(fails: Could not read package.json)*
- `apt-get install -y libgl1`
- `pytest` *(fails: Segmentation fault in onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_6894afdb578483218244ebe73465719f