### PR TITLE
feat: add collapsible sidebar with icons

### DIFF
--- a/webapp/frontend/alpr.html
+++ b/webapp/frontend/alpr.html
@@ -6,16 +6,18 @@
   <title>ALPR</title>
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="alpr.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
   <div class="sidebar">
+    <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
     <div class="flex items-center justify-center my-4">
       <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
       <h1 class="text-2xl font-bold text-white">TonAI</h1>
     </div>
-    <a href="index.html#/home" id="home-link">Home</a>
-    <a href="index.html#/training" id="training-link">Training</a>
-    <a href="index.html#/projects" id="projects-link" class="active">Projects</a>
+    <a href="index.html#/home" id="home-link"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
+    <a href="index.html#/training" id="training-link"><i class="fas fa-chalkboard-teacher"></i><span class="link-text">Training</span></a>
+    <a href="index.html#/projects" id="projects-link" class="active"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
   </div>
   <div class="main-content">
     <h1 class="text-5xl font-bold mb-10 text-center title">License Plate Recognition</h1>

--- a/webapp/frontend/alpr.js
+++ b/webapp/frontend/alpr.js
@@ -3,6 +3,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const alprResult = document.getElementById('alpr-result');
   const alprImageInput = document.getElementById('alpr-image');
   const alprUploadedImage = document.getElementById('alpr-uploaded-image');
+  const toggleBtn = document.getElementById('toggle-sidebar');
+  const sidebar = document.querySelector('.sidebar');
+
+  toggleBtn.addEventListener('click', () => {
+    const isCollapsed = sidebar.classList.toggle('collapsed');
+    toggleBtn.innerHTML = isCollapsed ? '<i class="fas fa-chevron-right"></i>' : '<i class="fas fa-chevron-left"></i>';
+  });
 
   alprImageInput.addEventListener('change', () => {
     const file = alprImageInput.files[0];

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -5,19 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TonAI Computer Vision Hub</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <button id="toggle-sidebar" class="toggle-btn">☰</button>
   <div class="sidebar">
+    <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
     <div class="flex items-center my-4">
       <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
       <h1 class="text-2xl font-bold text-white">TonAI</h1>
     </div>
-      <a href="#/home" id="home-link" class="active">Home</a>
-      <a href="#/training" id="training-link">Training</a>
-      <a href="#/datasets" id="datasets-link">Datasets</a>
-      <a href="#/projects" id="projects-link">Projects</a>
-      <a href="https://github.com/tungedng2710/license-plate-recognition" target="_blank">GitHub</a>
+      <a href="#/home" id="home-link" class="active"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
+      <a href="#/training" id="training-link"><i class="fas fa-chalkboard-teacher"></i><span class="link-text">Training</span></a>
+      <a href="#/datasets" id="datasets-link"><i class="fas fa-database"></i><span class="link-text">Datasets</span></a>
+      <a href="#/projects" id="projects-link"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
+      <a href="https://github.com/tungedng2710/license-plate-recognition" target="_blank"><i class="fab fa-github"></i><span class="link-text">GitHub</span></a>
     </div>
     <div class="main-content">
     <div id="home-page" class="flex justify-center items-center">

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -13,11 +13,9 @@
     const toggleBtn = document.getElementById('toggle-sidebar');
     const sidebar = document.querySelector('.sidebar');
 
-    toggleBtn.style.left = '210px';
-
     toggleBtn.addEventListener('click', () => {
-      const isHidden = sidebar.classList.toggle('hidden');
-      toggleBtn.style.left = isHidden ? '10px' : '210px';
+      const isCollapsed = sidebar.classList.toggle('collapsed');
+      toggleBtn.innerHTML = isCollapsed ? '<i class="fas fa-chevron-right"></i>' : '<i class="fas fa-chevron-left"></i>';
     });
 
     function handleRouteChange() {

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -19,16 +19,12 @@ body {
 }
 
 .toggle-btn {
-  position: fixed;
-  top: 10px;
-  left: 210px;
   background-color: #1f2937;
   color: white;
   border: none;
   padding: 10px;
   border-radius: 5px;
   cursor: pointer;
-  z-index: 1000;
 }
 
 .sidebar {
@@ -36,15 +32,46 @@ body {
   background-color: #1f2937;
   padding: 20px;
   flex-shrink: 0; /* Prevent sidebar from shrinking */
+  position: relative;
+  transition: width 0.3s;
+}
+
+.sidebar.collapsed {
+  width: 60px;
+}
+
+.sidebar .toggle-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.sidebar.collapsed .toggle-btn {
+  right: auto;
+  left: 10px;
 }
 
 .sidebar a {
-  display: block;
+  display: flex;
+  align-items: center;
   color: white;
   padding: 10px;
   text-decoration: none;
   border-radius: 5px;
   margin-bottom: 10px;
+  gap: 10px;
+}
+
+.sidebar.collapsed a {
+  justify-content: center;
+}
+
+.sidebar.collapsed a span {
+  display: none;
+}
+
+.sidebar.collapsed h1 {
+  display: none;
 }
 
 .sidebar a.active, .sidebar a:hover {


### PR DESCRIPTION
## Summary
- Add Font Awesome icons and move sidebar toggle inside the sidebar
- Collapse sidebar to icon-only view when hidden
- Apply collapsible behavior across index and ALPR pages

## Testing
- `npm test --prefix webapp/frontend` *(fails: Could not read package.json)*
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6894befda8d4832198de248f685c5f36