### PR TITLE
Add top bar with login button and darken home background

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -8,12 +8,16 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <div class="sidebar">
+  <div class="top-bar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
-    <div class="flex items-center my-4">
-      <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
-      <h1 class="text-2xl font-bold text-white">TonAI</h1>
-    </div>
+    <button id="login-btn" class="login-btn">Login</button>
+  </div>
+  <div class="layout">
+    <div class="sidebar">
+      <div class="flex items-center my-4">
+        <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
+        <h1 class="text-2xl font-bold text-white">TonAI</h1>
+      </div>
       <a href="#/home" id="home-link" class="active"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="#/training" id="training-link"><i class="fas fa-chalkboard-teacher"></i><span class="link-text">Training</span></a>
       <a href="#/datasets" id="datasets-link"><i class="fas fa-database"></i><span class="link-text">Datasets</span></a>
@@ -21,64 +25,64 @@
       <a href="https://github.com/tungedng2710/license-plate-recognition" target="_blank"><i class="fab fa-github"></i><span class="link-text">GitHub</span></a>
     </div>
     <div class="main-content">
-    <div id="home-page" class="flex justify-center items-center">
-      <div class="content">
-        <h1 class="title">TonAI Vision</h1>
-        <div class="buttons">
-          <button id="start-btn">Let's Start</button>
-          <a href="https://tungedng2710.github.io/" target="_blank"><button>About Us</button></a>
+      <div id="home-page" class="flex justify-center items-center">
+        <div class="content">
+          <h1 class="title">TonAI Vision</h1>
+          <div class="buttons">
+            <button id="start-btn">Let's Start</button>
+            <a href="https://tungedng2710.github.io/" target="_blank"><button>About Us</button></a>
+          </div>
         </div>
       </div>
-    </div>
       <div id="training-page" style="display: none;">
-      <h1 class="text-3xl font-bold mb-6 text-center">Train YOLO Models</h1>
+        <h1 class="text-3xl font-bold mb-6 text-center">Train YOLO Models</h1>
 
-      <section>
-        <h2 class="text-xl font-semibold mb-2">Available Datasets</h2>
-        <div id="datasets" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
-      </section>
-    
-      <section class="mt-8">
-        <h2 class="text-xl font-semibold mb-2">Training Configuration</h2>
-        <form id="trainForm" class="space-y-4 max-w-md">
-          <div>
-            <label class="block text-sm font-medium">Dataset</label>
-            <input id="dataset" required class="mt-1 w-full border rounded p-2" />
-          </div>
-          <div class="flex gap-4">
-            <div class="flex-1">
-              <label class="block text-sm font-medium">Batch Size</label>
-              <input type="number" id="batch" value="16" class="mt-1 w-full border rounded p-2" />
+        <section>
+          <h2 class="text-xl font-semibold mb-2">Available Datasets</h2>
+          <div id="datasets" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+        </section>
+
+        <section class="mt-8">
+          <h2 class="text-xl font-semibold mb-2">Training Configuration</h2>
+          <form id="trainForm" class="space-y-4 max-w-md">
+            <div>
+              <label class="block text-sm font-medium">Dataset</label>
+              <input id="dataset" required class="mt-1 w-full border rounded p-2" />
             </div>
-            <div class="flex-1">
-              <label class="block text-sm font-medium">Image Size</label>
-              <input type="number" id="img" value="640" class="mt-1 w-full border rounded p-2" />
+            <div class="flex gap-4">
+              <div class="flex-1">
+                <label class="block text-sm font-medium">Batch Size</label>
+                <input type="number" id="batch" value="16" class="mt-1 w-full border rounded p-2" />
+              </div>
+              <div class="flex-1">
+                <label class="block text-sm font-medium">Image Size</label>
+                <input type="number" id="img" value="640" class="mt-1 w-full border rounded p-2" />
+              </div>
             </div>
-          </div>
-          <div class="flex gap-4">
-            <div class="flex-1">
-              <label class="block text-sm font-medium">Model</label>
-              <select id="model" class="mt-1 w-full border rounded p-2">
-                <option value="m">yolov9-m</option>
-                <option value="c">yolov9-c</option>
-                <option value="t">yolov9-t</option>
-              </select>
+            <div class="flex gap-4">
+              <div class="flex-1">
+                <label class="block text-sm font-medium">Model</label>
+                <select id="model" class="mt-1 w-full border rounded p-2">
+                  <option value="m">yolov9-m</option>
+                  <option value="c">yolov9-c</option>
+                  <option value="t">yolov9-t</option>
+                </select>
+              </div>
+              <div class="flex-1">
+                <label class="block text-sm font-medium">Epochs</label>
+                <input type="number" id="epochs" value="100" class="mt-1 w-full border rounded p-2" />
+              </div>
             </div>
-            <div class="flex-1">
-              <label class="block text-sm font-medium">Epochs</label>
-              <input type="number" id="epochs" value="100" class="mt-1 w-full border rounded p-2" />
+            <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Train</button>
+          </form>
+
+          <div id="progressSection" class="mt-6 hidden max-w-md">
+            <div class="w-full bg-gray-200 rounded-full h-4">
+              <div id="progressBar" class="bg-blue-600 h-4 rounded-full" style="width: 0%"></div>
             </div>
+            <p id="progressText" class="text-sm mt-1 text-gray-700">0%</p>
           </div>
-          <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Train</button>
-        </form>
-    
-        <div id="progressSection" class="mt-6 hidden max-w-md">
-          <div class="w-full bg-gray-200 rounded-full h-4">
-            <div id="progressBar" class="bg-blue-600 h-4 rounded-full" style="width: 0%"></div>
-          </div>
-          <p id="progressText" class="text-sm mt-1 text-gray-700">0%</p>
-        </div>
-      </section>
+        </section>
       </div>
       <div id="datasets-page" style="display: none;">
         <h1 class="text-3xl font-bold mb-6 text-center">Datasets</h1>
@@ -92,20 +96,21 @@
         </div>
       </div>
     </div>
-    <div id="dataset-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
-      <div class="bg-white text-black p-6 rounded-lg w-80">
-        <div class="flex justify-between items-center mb-4">
-          <h2 id="modal-title" class="text-xl font-bold"></h2>
-          <button id="modal-close" class="text-gray-500">&times;</button>
-        </div>
-        <canvas id="datasetChart" class="mb-4"></canvas>
-        <p id="dataset-counts" class="text-center"></p>
+  </div>
+  <div id="dataset-modal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+    <div class="bg-white text-black p-6 rounded-lg w-80">
+      <div class="flex justify-between items-center mb-4">
+        <h2 id="modal-title" class="text-xl font-bold"></h2>
+        <button id="modal-close" class="text-gray-500">&times;</button>
       </div>
+      <canvas id="datasetChart" class="mb-4"></canvas>
+      <p id="dataset-counts" class="text-center"></p>
     </div>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.waves.min.js"></script>
-    <script src="script.js"></script>
+  </div>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.waves.min.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -15,10 +15,10 @@
 
    VANTA.WAVES({
      el: '#home-page',
-     color: 0x1d4ed8,
-     shininess: 50,
-     waveHeight: 20,
-     waveSpeed: 0.75,
+     color: 0x001f3f,
+     shininess: 20,
+     waveHeight: 10,
+     waveSpeed: 0.5,
      zoom: 0.8
    });
 

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -13,6 +13,7 @@ body {
   font-family: 'Roboto', sans-serif;
   margin: 0;
   display: flex;
+  flex-direction: column;
   background-color: #111827;
   color: white;
   height: 100%;
@@ -23,6 +24,29 @@ body {
   color: white;
   border: none;
   padding: 10px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.top-bar {
+  height: 50px;
+  background-color: #1f2937;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 20px;
+}
+
+.layout {
+  display: flex;
+  flex: 1;
+}
+
+.login-btn {
+  background-color: transparent;
+  border: 1px solid white;
+  color: white;
+  padding: 8px 16px;
   border-radius: 5px;
   cursor: pointer;
 }
@@ -38,17 +62,6 @@ body {
 
 .sidebar.collapsed {
   width: 60px;
-}
-
-.sidebar .toggle-btn {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-}
-
-.sidebar.collapsed .toggle-btn {
-  right: auto;
-  left: 10px;
 }
 
 .sidebar a {
@@ -132,7 +145,6 @@ body {
     border-radius: 8px;
 }
 
-
 #datasets div img {
   object-fit: cover;
   height: 100px; /* Or any other fixed height */
@@ -153,7 +165,6 @@ body {
     padding: 20px;
     border-radius: 8px;
 }
-
 
 #projects-page .title {
   font-size: 3rem;
@@ -223,4 +234,3 @@ body {
 #dataset-modal canvas {
   max-width: 100%;
 }
-


### PR DESCRIPTION
## Summary
- Add a new top navigation bar with sidebar toggle and dummy login button
- Convert layout to column-based and style the new top bar and login button
- Darken home page wave background and reduce its motion

## Testing
- `/usr/bin/npm test` (fails: No such file or directory)
- `/usr/bin/python3 -m pytest` (fails: No module named pytest)


------
https://chatgpt.com/codex/tasks/task_e_6894cab2426c8321924cdf4fc1c188a9