### PR TITLE
feat: update training page with new models

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -63,9 +63,11 @@
               <div class="flex-1">
                 <label class="block text-sm font-medium">Model</label>
                 <select id="model" class="mt-1 w-full border rounded p-2">
-                  <option value="m">yolov9-m</option>
-                  <option value="c">yolov9-c</option>
-                  <option value="t">yolov9-t</option>
+                  <option value="yolov8n">yolov8n</option>
+                  <option value="yolov8s">yolov8s</option>
+                  <option value="yolov8m">yolov8m</option>
+                  <option value="yolo11n">yolo11n</option>
+                  <option value="yolo11x">yolo11x</option>
                 </select>
               </div>
               <div class="flex-1">


### PR DESCRIPTION
## Summary
- add yolov8 and yolo11 model options to training UI
- route training requests through yolo_trainer with progress callback

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6895684840108321ac6736ebbfe1fb79