### PR TITLE
feat: update training page with new models

### DIFF
--- a/sync_with_minio.sh
+++ b/sync_with_minio.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
-DATASET="$1"
-TARGET_DIR="datasets/$DATASET"
+
+DATASET_DIR="$1"
 CONFIG_FILE="minio_config.json"
 
 ENDPOINT=$(jq -r '.endpoint' "$CONFIG_FILE")
@@ -9,8 +9,21 @@ ACCESS_KEY=$(jq -r '.access_key' "$CONFIG_FILE")
 SECRET_KEY=$(jq -r '.secret_key' "$CONFIG_FILE")
 BUCKET=$(jq -r '.bucket' "$CONFIG_FILE")
 
-mkdir -p "$TARGET_DIR"
+# Configure MinIO alias
 if command -v mc >/dev/null 2>&1; then
-  mc alias set local "$ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY" >/dev/null 2>&1 || true
-  mc cp --recursive "local/$BUCKET/$DATASET" "$TARGET_DIR" >/dev/null 2>&1 || true
+  mc alias set local "$ENDPOINT" "$ACCESS_KEY" "$SECRET_KEY"
+
+  TARGET_DIR="datasets/$DATASET_DIR"
+  mkdir -p "$TARGET_DIR"
+
+  # Mirror dataset from MinIO to local directory
+  mc mirror --overwrite "local/$BUCKET/$DATASET_DIR" "$TARGET_DIR/"
+
+  # Update data.yaml files with absolute paths
+  cd "$TARGET_DIR"
+  for yaml_file in $(find . -name "data.yaml"); do
+    sed -i "s|train: |train: $(pwd)/|" "$yaml_file"
+    sed -i "s|val: |val: $(pwd)/|" "$yaml_file"
+    sed -i "s|test: |test: $(pwd)/|" "$yaml_file"
+  done
 fi

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -63,9 +63,11 @@
               <div class="flex-1">
                 <label class="block text-sm font-medium">Model</label>
                 <select id="model" class="mt-1 w-full border rounded p-2">
-                  <option value="m">yolov9-m</option>
-                  <option value="c">yolov9-c</option>
-                  <option value="t">yolov9-t</option>
+                  <option value="yolov8n">yolov8n</option>
+                  <option value="yolov8s">yolov8s</option>
+                  <option value="yolov8m">yolov8m</option>
+                  <option value="yolo11n">yolo11n</option>
+                  <option value="yolo11x">yolo11x</option>
                 </select>
               </div>
               <div class="flex-1">


### PR DESCRIPTION
## Summary
- add yolov8 and yolo11 model options to training UI
- route training requests through yolo_trainer with progress callback
- sync requested dataset from MinIO and set environment for trainer

## Testing
- `apt-get install -y libgl1`
- `pytest -q` *(fails: Segmentation fault in onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_6895684840108321ac6736ebbfe1fb79