### PR TITLE
Improve sidebar navigation and user controls

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -10,19 +10,20 @@
 <body>
   <div class="top-bar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
-    <button id="login-btn" class="login-btn">Login</button>
+    <button id="logout-btn" class="login-btn">Logout</button>
   </div>
   <div class="layout">
     <div class="sidebar">
-      <div class="flex items-center my-4">
+      <a href="#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
         <h1 class="text-2xl font-bold text-white">TonAI</h1>
-      </div>
+      </a>
       <a href="#/home" id="home-link" class="active"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="#/training" id="training-link"><i class="fas fa-chalkboard-teacher"></i><span class="link-text">Training</span></a>
       <a href="#/datasets" id="datasets-link"><i class="fas fa-database"></i><span class="link-text">Datasets</span></a>
       <a href="#/projects" id="projects-link"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
       <a href="https://github.com/tungedng2710/license-plate-recognition" target="_blank"><i class="fab fa-github"></i><span class="link-text">GitHub</span></a>
+      <a href="#/settings" class="user-settings"><img src="https://via.placeholder.com/32" alt="User Avatar" class="h-8 w-8 rounded-full mr-2"><span class="link-text">Admin</span></a>
     </div>
     <div class="main-content">
       <div id="home-page" class="flex justify-center items-center">

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -58,10 +58,13 @@ body {
   flex-shrink: 0; /* Prevent sidebar from shrinking */
   position: relative;
   transition: width 0.3s;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar.collapsed {
-  width: 60px;
+  width: 72px;
+  padding: 20px 0;
 }
 
 .sidebar a {
@@ -89,6 +92,14 @@ body {
 
 .sidebar a.active, .sidebar a:hover {
   background-color: #374151;
+}
+
+.user-settings {
+  margin-top: auto;
+}
+
+.sidebar.collapsed .user-settings {
+  justify-content: center;
 }
 
 .main-content {


### PR DESCRIPTION
## Summary
- make TonAI logo link back to home
- tighten collapsed sidebar width to match logo and add user settings
- swap login button for logout placeholder

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6895acbf0b548321bdd5842267ff1dee