### PR TITLE
Add login page and sidebar improvements

### DIFF
--- a/webapp/frontend/alpr.html
+++ b/webapp/frontend/alpr.html
@@ -11,13 +11,14 @@
 <body>
   <div class="sidebar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
-    <div class="flex items-center justify-center my-4">
+    <a href="index.html#/home" id="logo-link" class="flex items-center my-4">
       <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
       <h1 class="text-2xl font-bold text-white">TonAI</h1>
-    </div>
+    </a>
     <a href="index.html#/home" id="home-link"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
     <a href="index.html#/training" id="training-link"><i class="fas fa-chalkboard-teacher"></i><span class="link-text">Training</span></a>
     <a href="index.html#/projects" id="projects-link" class="active"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
+    <a href="#/settings" class="user-settings"><img src="https://github.com/tungedng2710/tungedng2710.github.io/blob/main/assets/images/logo.png?raw=true" alt="User Avatar" class="h-8 w-8 rounded-full mr-2"><span class="link-text">Edward</span></a>
   </div>
   <div class="main-content">
     <h1 class="text-5xl font-bold mb-10 text-center title">License Plate Recognition</h1>
@@ -39,6 +40,7 @@
     </div>
   </div>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="auth.js"></script>
   <script src="alpr.js"></script>
 </body>
 </html>

--- a/webapp/frontend/auth.js
+++ b/webapp/frontend/auth.js
@@ -1,0 +1,18 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const logoutBtn = document.getElementById('logout-btn');
+  if (logoutBtn) {
+    logoutBtn.addEventListener('click', () => {
+      localStorage.removeItem('authenticated');
+      window.location.href = 'login.html';
+    });
+  }
+
+  const isLoginPage = window.location.pathname.endsWith('login.html');
+  const authenticated = localStorage.getItem('authenticated');
+  if (!isLoginPage && !authenticated) {
+    window.location.href = 'login.html';
+  }
+  if (isLoginPage && authenticated) {
+    window.location.href = 'index.html';
+  }
+});

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -115,6 +115,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.waves.min.js"></script>
+  <script src="auth.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/webapp/frontend/login.html
+++ b/webapp/frontend/login.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Login - TonAI Vision</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 flex items-center justify-center h-screen">
+  <div class="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-sm">
+    <div class="flex justify-center mb-6">
+      <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-16 w-16">
+    </div>
+    <h2 class="text-2xl font-bold text-center text-white mb-6">TonAI Vision Login</h2>
+    <form id="login-form" class="space-y-4">
+      <input id="username" type="text" placeholder="Username" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none" required>
+      <input id="password" type="password" placeholder="Password" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none" required>
+      <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded">Login</button>
+      <p id="login-error" class="text-red-500 text-sm text-center hidden">Invalid credentials</p>
+    </form>
+  </div>
+  <script src="auth.js"></script>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/webapp/frontend/login.js
+++ b/webapp/frontend/login.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('login-form');
+  const errorMsg = document.getElementById('login-error');
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+
+    if (username === 'admin' && password === 'admin') {
+      localStorage.setItem('authenticated', 'true');
+      window.location.href = 'index.html';
+    } else {
+      errorMsg.classList.remove('hidden');
+    }
+  });
+});

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -51,6 +51,7 @@ body {
   cursor: pointer;
 }
 
+/* Sidebar layout */
 .sidebar {
   width: 200px;
   background-color: #1f2937;
@@ -62,9 +63,9 @@ body {
   flex-direction: column;
 }
 
+/* Collapsed state only hides text while keeping width */
 .sidebar.collapsed {
-  width: 72px;
-  padding: 20px 0;
+  width: 200px; /* keep original width */
 }
 
 .sidebar a {
@@ -82,12 +83,14 @@ body {
   justify-content: center;
 }
 
-.sidebar.collapsed a span {
+.sidebar.collapsed .link-text,
+.sidebar.collapsed h1 {
   display: none;
 }
 
-.sidebar.collapsed h1 {
-  display: none;
+.sidebar.collapsed #logo-link img,
+.sidebar.collapsed .user-settings img {
+  margin-right: 0;
 }
 
 .sidebar a.active, .sidebar a:hover {
@@ -96,10 +99,6 @@ body {
 
 .user-settings {
   margin-top: auto;
-}
-
-.sidebar.collapsed .user-settings {
-  justify-content: center;
 }
 
 .main-content {


### PR DESCRIPTION
## Summary
- keep sidebar width and show logo/user avatar when collapsed
- add authentication utilities and login page
- redirect logout to login page

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6895b318d3e0832195c55bf8150691b0