### PR TITLE
Fix sidebar collapse width for logo and avatar visibility

### DIFF
--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -63,9 +63,9 @@ body {
   flex-direction: column;
 }
 
-/* Collapsed state only hides text while keeping width */
+/* Collapsed state shows only icons but keeps enough space for images */
 .sidebar.collapsed {
-  width: 200px; /* keep original width */
+  width: 80px; /* enough width for logo and avatar */
 }
 
 .sidebar a {


### PR DESCRIPTION
## Summary
- Ensure collapsed sidebar remains wide enough for tonAI logo and user avatar

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895c5e0e8a48321b3c6ec32c856c935