### PR TITLE
feat(frontend): redesign home background and title glow

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -113,8 +113,6 @@
   </div>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r121/three.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/vanta/0.5.24/vanta.waves.min.js"></script>
   <script src="auth.js"></script>
   <script src="script.js"></script>
 </body>

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -13,15 +13,6 @@
   const toggleBtn = document.getElementById('toggle-sidebar');
   const sidebar = document.querySelector('.sidebar');
 
-   VANTA.WAVES({
-     el: '#home-page',
-     color: 0x001f3f,
-     shininess: 20,
-     waveHeight: 10,
-     waveSpeed: 0.5,
-     zoom: 0.8
-   });
-
     toggleBtn.addEventListener('click', () => {
       const isCollapsed = sidebar.classList.toggle('collapsed');
       toggleBtn.innerHTML = isCollapsed ? '<i class="fas fa-chevron-right"></i>' : '<i class="fas fa-chevron-left"></i>';

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -108,6 +108,7 @@ body {
   overflow-y: auto; /* Allow scrolling for content that overflows */
 }
 
+
 #home-page {
   position: relative;
   display: flex;
@@ -116,6 +117,24 @@ body {
   text-align: center;
   overflow: hidden;
   height: 100%;
+  background: linear-gradient(-45deg, #001f3f, #001633, #000d1f, #001633);
+  background-size: 400% 400%;
+  animation: ambientMove 20s ease infinite;
+}
+
+#home-page::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 200%;
+  height: 200%;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4MDAgNDAwIj4KICA8cGF0aCBkPSJNMCAyMDAgUSAxNTAgMTAwIDMwMCAyMDAgVDYwMCAyMDAgVDkwMCAyMDAiIHN0cm9rZT0icmdiYSgyNTUsMjU1LDI1NSwwLjE1KSIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJub25lIi8+CiAgPHBhdGggZD0iTTAgMzAwIFEgMTUwIDIwMCAzMDAgMzAwIFQ2MDAgMzAwIFQ5MDAgMzAwIiBzdHJva2U9InJnYmEoMjU1LDI1NSwyNTUsMC4xKSIgc3Ryb2tlLXdpZHRoPSIyIiBmaWxsPSJub25lIi8+Cjwvc3ZnPgo=");
+  background-repeat: repeat;
+  background-size: 200% 100%;
+  animation: waveMove 10s linear infinite;
+  opacity: 0.2;
+  pointer-events: none;
 }
 
 #home-page .content {
@@ -123,10 +142,17 @@ body {
 }
 
 #home-page .title {
-  font-size: 5rem;
+  font-size: 6rem;
   font-weight: bold;
   color: white;
-  text-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
+  letter-spacing: 0.1em;
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
+  transition: text-shadow 0.3s, transform 0.3s;
+}
+
+#home-page .title:hover {
+  text-shadow: 0 0 40px rgba(255, 255, 255, 0.7);
+  transform: scale(1.05);
 }
 
 #home-page .buttons {
@@ -146,6 +172,27 @@ body {
 
 #home-page button:hover {
   background-color: rgba(255, 255, 255, 0.2);
+}
+
+@keyframes ambientMove {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes waveMove {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: -200px 0;
+  }
 }
 
 #training-page {


### PR DESCRIPTION
## Summary
- replace home page wave animation with dark blue ambient gradient and subtle wave lines
- expand TonAI Vision title and add soft glowing hover effect

## Testing
- `pytest` *(fails: libGL.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6896e1a559d883219ea333c077d2903b