### PR TITLE
feat: enhance dataset management UI

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -90,6 +90,10 @@
       </div>
       <div id="datasets-page" style="display: none;">
         <h1 class="text-3xl font-bold mb-6 text-center">Datasets</h1>
+        <div class="text-right mb-4">
+          <input type="file" id="dataset-upload" accept=".zip" class="hidden" />
+          <button id="upload-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
+        </div>
         <div id="dataset-cards" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
       </div>
       <div id="projects-page" style="display: none;">

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -265,18 +265,37 @@ body {
 }
 
 .dataset-card {
-  background: rgba(255, 255, 255, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(5px);
-  padding: 20px;
-  text-align: center;
+  background: #fff;
+  color: #333;
   border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   cursor: pointer;
-  transition: background 0.3s;
+  transition: transform 0.2s;
 }
 
 .dataset-card:hover {
-  background: rgba(255, 255, 255, 0.4);
+  transform: translateY(-4px);
+}
+
+.dataset-card img {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+}
+
+.dataset-card .tags {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.dataset-card .tags span {
+  background: #e5e7eb;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75rem;
 }
 
 #dataset-modal canvas {


### PR DESCRIPTION
## Summary
- show dataset info as rich cards with thumbnails and stats
- allow uploading zip datasets via new API endpoint

## Testing
- `python -m py_compile webapp/backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68986cc06ed48321bc16191f796b396d