### PR TITLE
feat: add dataset thumbnails

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -94,7 +94,7 @@
           <input type="file" id="dataset-upload" accept=".zip" class="hidden" />
           <button id="upload-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
         </div>
-        <div id="dataset-cards" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+        <div id="dataset-cards"></div>
       </div>
       <div id="projects-page" style="display: none;">
         <h1 class="text-5xl font-bold mb-10 text-center title">Projects</h1>

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -118,7 +118,7 @@
       const div = document.createElement('div');
       div.className = 'dataset-card';
       div.innerHTML = `
-        <img src="https://picsum.photos/seed/${ds}/300/150" alt="${ds} thumbnail" />
+        <img src="/api/datasets/${ds}/thumbnail" alt="${ds} thumbnail" />
         <div class="p-4">
           <h3 class="text-lg font-bold mb-2">${ds}</h3>
           <p class="text-sm mb-1">Classes: ${stats.classes}</p>

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -260,7 +260,8 @@ body {
 }
 
 #dataset-cards {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- show datasets as a single-column list of cards
- load real dataset thumbnails via new API endpoint

## Testing
- `pytest -q` *(fails: Segmentation fault)*

------
https://chatgpt.com/codex/tasks/task_e_689959ec305c8321887ca8c3f28ceb1d