### PR TITLE
Improve frontend styling and default sidebar collapse

### DIFF
--- a/webapp/frontend/alpr.html
+++ b/webapp/frontend/alpr.html
@@ -10,11 +10,11 @@
 </head>
 <body>
   <div class="top-bar">
-    <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
+    <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-right"></i></button>
     <button id="logout-btn" class="login-btn">Logout</button>
   </div>
   <div class="layout">
-    <div class="sidebar">
+    <div class="sidebar collapsed">
       <a href="index.html#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
         <h1 class="text-2xl font-bold text-white">TonAI</h1>

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -7,13 +7,13 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
+<body class="home-bg">
   <div class="top-bar">
-    <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
+    <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-right"></i></button>
     <button id="logout-btn" class="login-btn">Logout</button>
   </div>
   <div class="layout">
-    <div class="sidebar">
+    <div class="sidebar collapsed">
       <a href="#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
         <h1 class="text-2xl font-bold text-white">TonAI</h1>
@@ -89,10 +89,12 @@
         </section>
       </div>
       <div id="datasets-page" style="display: none;">
-        <h1 class="text-3xl font-bold mb-6 text-center">Datasets</h1>
-        <div class="text-right mb-4">
-          <input type="file" id="dataset-upload" accept=".zip" class="hidden" />
-          <button id="upload-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
+        <div class="flex items-center justify-between mb-6">
+          <h1 class="text-3xl font-bold">Datasets</h1>
+          <div>
+            <input type="file" id="dataset-upload" accept=".zip" class="hidden" />
+            <button id="upload-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
+          </div>
         </div>
         <div id="dataset-cards"></div>
       </div>

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -12,8 +12,9 @@
     const uploadInput = document.getElementById('dataset-upload');
   const modalClose = document.getElementById('modal-close');
   const startBtn = document.getElementById('start-btn');
-  const toggleBtn = document.getElementById('toggle-sidebar');
-  const sidebar = document.querySelector('.sidebar');
+    const toggleBtn = document.getElementById('toggle-sidebar');
+    const sidebar = document.querySelector('.sidebar');
+    const body = document.body;
 
     toggleBtn.addEventListener('click', () => {
       const isCollapsed = sidebar.classList.toggle('collapsed');
@@ -36,6 +37,7 @@
 
     function handleRouteChange() {
       const hash = window.location.hash;
+      body.classList.remove('home-bg');
       if (hash === '#/training') {
         homePage.style.display = 'none';
         trainingPage.style.display = 'block';
@@ -73,6 +75,7 @@
         trainingLink.classList.remove('active');
         datasetsLink.classList.remove('active');
         projectsLink.classList.remove('active');
+        body.classList.add('home-bg');
       }
     }
 

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -14,6 +14,10 @@ body {
   margin: 0;
   color: white;
   height: 100vh;
+  background-color: #1f2937;
+}
+
+body.home-bg {
   background-image: url('https://raw.githubusercontent.com/tungedng2710/tungedng2710.github.io/main/assets/images/heroimage.png');
   background-size: cover;
   background-position: center;
@@ -187,10 +191,7 @@ body {
 
 
 #training-page {
-    background-color: #f3f4f6;
-    color: #333;
     padding: 20px;
-    border-radius: 8px;
 }
 
 #datasets div img {
@@ -200,18 +201,21 @@ body {
 
 #datasets div {
     background-color: white;
+    color: #333;
 }
 
 #trainForm {
     background-color: white;
     padding: 20px;
     border-radius: 8px;
+    color: #333;
 }
 
 #progressSection {
     background-color: white;
     padding: 20px;
     border-radius: 8px;
+    color: #333;
 }
 
 #projects-page .title {
@@ -253,10 +257,7 @@ body {
 }
 
 #datasets-page {
-  background-color: #f3f4f6;
-  color: #333;
-  padding: 20px;
-  border-radius: 8px;
+    padding: 20px;
 }
 
 #dataset-cards {


### PR DESCRIPTION
## Summary
- Show background image only on the homepage and use dark blue elsewhere
- Collapse the sidebar by default on all pages
- Align dataset title with its card list

## Testing
- `pytest` *(fails: libGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899621e27448321a18f9dc08ec25c50