### PR TITLE
feat(webapp): add RTSP streaming to ALPR page

### DIFF
--- a/webapp/frontend/alpr.css
+++ b/webapp/frontend/alpr.css
@@ -28,6 +28,28 @@
   background-color: #1d4ed8;
 }
 
+#alpr-stream-form input[type="text"] {
+  background-color: #374151;
+  color: white;
+  border: 1px solid #4b5563;
+  border-radius: 4px;
+  padding: 8px;
+}
+
+#alpr-stream-form button {
+  background-color: #2563eb;
+  color: white;
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+#alpr-stream-form button:hover {
+  background-color: #1d4ed8;
+}
+
 .image-container {
     display: flex;
     justify-content: space-around;
@@ -42,7 +64,17 @@
     background-color: #1f2937;
 }
 
+#stream-box {
+  width: 90%;
+}
+
 #alpr-uploaded-image, #alpr-result {
+  margin-top: 20px;
+  border: 2px solid #374151;
+  border-radius: 8px;
+}
+
+#alpr-stream {
   margin-top: 20px;
   border: 2px solid #374151;
   border-radius: 8px;

--- a/webapp/frontend/alpr.html
+++ b/webapp/frontend/alpr.html
@@ -21,7 +21,9 @@
       </a>
       <a href="index.html#/home" id="home-link"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="index.html#/training" id="training-link"><i class="fas fa-chalkboard-teacher"></i><span class="link-text">Training</span></a>
+      <a href="index.html#/datasets" id="datasets-link"><i class="fas fa-database"></i><span class="link-text">Datasets</span></a>
       <a href="index.html#/projects" id="projects-link" class="active"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
+      <a href="https://github.com/tungedng2710/license-plate-recognition" target="_blank"><i class="fab fa-github"></i><span class="link-text">GitHub</span></a>
       <a href="#/settings" class="user-settings"><img src="https://github.com/tungedng2710/tungedng2710.github.io/blob/main/assets/images/logo.png?raw=true" alt="User Avatar" class="h-8 w-8 rounded-full mr-2"><span class="link-text">Edward</span></a>
     </div>
     <div class="main-content">
@@ -40,6 +42,14 @@
             <h2 class="text-2xl font-bold mb-4 text-center">Result Image</h2>
             <img id="alpr-result" class="max-w-full" />
           </div>
+        </div>
+        <form id="alpr-stream-form" class="mb-4 mt-6 flex">
+          <input type="text" id="alpr-rtsp" placeholder="RTSP URL" class="mb-2 p-2 rounded flex-1" required />
+          <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded ml-2">Stream</button>
+        </form>
+        <div class="image-box" id="stream-box">
+          <h2 class="text-2xl font-bold mb-4 text-center">Video Stream</h2>
+          <img id="alpr-stream" class="max-w-full" />
         </div>
       </div>
     </div>

--- a/webapp/frontend/alpr.js
+++ b/webapp/frontend/alpr.js
@@ -3,13 +3,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const alprResult = document.getElementById('alpr-result');
   const alprImageInput = document.getElementById('alpr-image');
   const alprUploadedImage = document.getElementById('alpr-uploaded-image');
-  const toggleBtn = document.getElementById('toggle-sidebar');
-  const sidebar = document.querySelector('.sidebar');
-
-  toggleBtn.addEventListener('click', () => {
-    const isCollapsed = sidebar.classList.toggle('collapsed');
-    toggleBtn.innerHTML = isCollapsed ? '<i class="fas fa-chevron-right"></i>' : '<i class="fas fa-chevron-left"></i>';
-  });
+  const streamForm = document.getElementById('alpr-stream-form');
+  const streamUrl = document.getElementById('alpr-rtsp');
+  const streamImage = document.getElementById('alpr-stream');
 
   alprImageInput.addEventListener('change', () => {
     const file = alprImageInput.files[0];
@@ -31,5 +27,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const res = await fetch('/api/alpr', { method: 'POST', body: formData });
     const blob = await res.blob();
     alprResult.src = URL.createObjectURL(blob);
+  });
+
+  streamForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const url = streamUrl.value.trim();
+    if (!url) return;
+    streamImage.src = `/api/alpr/stream?url=${encodeURIComponent(url)}`;
   });
 });


### PR DESCRIPTION
## Summary
- support RTSP video streaming with ALPR overlay
- align ALPR page sidebar with homepage navigation
- allow entering RTSP URLs and viewing streams in the ALPR web UI

## Testing
- `pytest` *(fails: ImportError libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_689d9988273c83219632fc1daf112d84