### PR TITLE
Use Orbitron font and downscale streamers to HD

### DIFF
--- a/webapp/backend/main.py
+++ b/webapp/backend/main.py
@@ -26,6 +26,7 @@ REPO_ROOT = BASE_DIR.parent
 TRAIN_SCRIPT = BASE_DIR / "yolo_trainer" / "train.py"
 SYNC_SCRIPT = REPO_ROOT / "sync_with_minio.sh"
 RTSP_FILE = BASE_DIR / "rtsp_url.json"
+HD_SIZE = (1280, 720)
 
 with open(REPO_ROOT / "minio_config.json") as f:
     MINIO_CFG = json.load(f)
@@ -272,6 +273,7 @@ def video_stream(url: str):
             ret, frame = cap.read()
             if not ret:
                 break
+            frame = cv2.resize(frame, HD_SIZE)
             _, buffer = cv2.imencode('.jpg', frame)
             yield (
                 b"--frame\r\n"
@@ -294,6 +296,7 @@ def alpr_stream(url: str):
                 break
             alpr_model.vehicles = []
             frame = alpr_model(frame)
+            frame = cv2.resize(frame, HD_SIZE)
             _, buffer = cv2.imencode('.jpg', frame)
             yield (
                 b"--frame\r\n"

--- a/webapp/frontend/login.html
+++ b/webapp/frontend/login.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - TonAI Vision</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body class="bg-gray-900 flex items-center justify-center h-screen">
   <div class="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-sm">

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Orbitron&display=swap');
 
 html {
   box-sizing: border-box;
@@ -10,7 +10,7 @@ html {
 }
 
 body {
-  font-family: 'Roboto', sans-serif;
+  font-family: 'Orbitron', sans-serif;
   margin: 0;
   color: white;
   height: 100vh;


### PR DESCRIPTION
## Summary
- Adopt Orbitron as the global typeface across the frontend
- Downscale streaming output to HD resolution for smoother delivery

## Testing
- `pytest -q` *(fails: segmentation fault in onnxruntime during test import)*

------
https://chatgpt.com/codex/tasks/task_e_689eb89068108321a519e63e5857391a