### PR TITLE
Add video wallpaper and center homepage title

### DIFF
--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -8,6 +8,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="home-bg">
+  <video autoplay muted loop id="bg-video">
+    <source src="static/mylivewallpapers.mp4" type="video/mp4">
+  </video>
   <div class="top-bar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-right"></i></button>
     <button id="logout-btn" class="login-btn">Logout</button>

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -18,10 +18,22 @@ body {
 }
 
 body.home-bg {
-  background-image: url('https://raw.githubusercontent.com/tungedng2710/tungedng2710.github.io/main/assets/images/heroimage.png');
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
+  /* Video background handled via #bg-video */
+}
+
+#bg-video {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -1;
+  display: none;
+}
+
+body.home-bg #bg-video {
+  display: block;
 }
 
 .toggle-btn {
@@ -153,6 +165,11 @@ body.home-bg {
 
 #home-page .content {
   z-index: 1;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
 }
 
 #home-page .title {


### PR DESCRIPTION
## Summary
- Center the TonAI Vision heading on the home page
- Replace static background with looping `mylivewallpapers.mp4` video

## Testing
- `pytest` *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689ee31b9b748321a9986ab5951afd99