### PR TITLE
Use live wallpaper for frontend background

### DIFF
--- a/webapp/frontend/alpr.html
+++ b/webapp/frontend/alpr.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
+  <video autoplay muted loop id="bg-video">
+    <source src="static/mylivewallpapers.mp4" type="video/mp4">
+  </video>
   <div class="top-bar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-right"></i></button>
     <button id="logout-btn" class="login-btn">Logout</button>

--- a/webapp/frontend/alpr_stream.html
+++ b/webapp/frontend/alpr_stream.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
+  <video autoplay muted loop id="bg-video">
+    <source src="static/mylivewallpapers.mp4" type="video/mp4">
+  </video>
   <div class="top-bar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-right"></i></button>
     <button id="logout-btn" class="login-btn">Logout</button>

--- a/webapp/frontend/alpr_upload.html
+++ b/webapp/frontend/alpr_upload.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
+  <video autoplay muted loop id="bg-video">
+    <source src="static/mylivewallpapers.mp4" type="video/mp4">
+  </video>
   <div class="top-bar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-right"></i></button>
     <button id="logout-btn" class="login-btn">Logout</button>

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body class="home-bg">
+<body>
   <video autoplay muted loop id="bg-video">
     <source src="static/mylivewallpapers.mp4" type="video/mp4">
   </video>

--- a/webapp/frontend/login.html
+++ b/webapp/frontend/login.html
@@ -7,7 +7,10 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="bg-gray-900 flex items-center justify-center h-screen">
+<body class="flex items-center justify-center h-screen">
+  <video autoplay muted loop id="bg-video">
+    <source src="static/mylivewallpapers.mp4" type="video/mp4">
+  </video>
   <div class="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-sm">
     <div class="flex justify-center mb-6">
       <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-16 w-16">

--- a/webapp/frontend/script.js
+++ b/webapp/frontend/script.js
@@ -14,7 +14,6 @@
   const startBtn = document.getElementById('start-btn');
     const toggleBtn = document.getElementById('toggle-sidebar');
     const sidebar = document.querySelector('.sidebar');
-    const body = document.body;
 
     toggleBtn.addEventListener('click', () => {
       const isCollapsed = sidebar.classList.toggle('collapsed');
@@ -37,7 +36,6 @@
 
     function handleRouteChange() {
       const hash = window.location.hash;
-      body.classList.remove('home-bg');
       if (hash === '#/training') {
         homePage.style.display = 'none';
         trainingPage.style.display = 'block';
@@ -75,7 +73,6 @@
         trainingLink.classList.remove('active');
         datasetsLink.classList.remove('active');
         projectsLink.classList.remove('active');
-        body.classList.add('home-bg');
       }
     }
 

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -17,10 +17,6 @@ body {
   background-color: #1f2937;
 }
 
-body.home-bg {
-  /* Video background handled via #bg-video */
-}
-
 #bg-video {
   position: fixed;
   top: 0;
@@ -29,11 +25,6 @@ body.home-bg {
   height: 100%;
   object-fit: cover;
   z-index: -1;
-  display: none;
-}
-
-body.home-bg #bg-video {
-  display: block;
 }
 
 .toggle-btn {

--- a/webapp/frontend/video_management.html
+++ b/webapp/frontend/video_management.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
+  <video autoplay muted loop id="bg-video">
+    <source src="static/mylivewallpapers.mp4" type="video/mp4">
+  </video>
   <div class="top-bar">
     <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-right"></i></button>
     <button id="logout-btn" class="login-btn">Logout</button>


### PR DESCRIPTION
## Summary
- remove legacy home-bg class and always show the live wallpaper video
- replace static backgrounds across HTML pages with live video background

## Testing
- `pytest` *(fails: Fatal Python error: Segmentation fault)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ee6032b2883219d89732b8b54fbc0