### PR TITLE
fix: display WebRTC stream

### DIFF
--- a/webapp/frontend/alpr_stream.js
+++ b/webapp/frontend/alpr_stream.js
@@ -29,7 +29,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     pc = new RTCPeerConnection();
     pc.ontrack = (e) => {
-      videoEl.srcObject = e.streams[0];
+      if (e.streams && e.streams[0]) {
+        videoEl.srcObject = e.streams[0];
+      } else {
+        const stream = new MediaStream();
+        stream.addTrack(e.track);
+        videoEl.srcObject = stream;
+      }
     };
     pc.addTransceiver('video', { direction: 'recvonly' });
     const offer = await pc.createOffer();

--- a/webapp/frontend/video_management.js
+++ b/webapp/frontend/video_management.js
@@ -47,7 +47,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
       pc = new RTCPeerConnection();
       pc.ontrack = (e) => {
-        videoEl.srcObject = e.streams[0];
+        if (e.streams && e.streams[0]) {
+          videoEl.srcObject = e.streams[0];
+        } else {
+          const stream = new MediaStream();
+          stream.addTrack(e.track);
+          videoEl.srcObject = stream;
+        }
       };
       pc.addTransceiver('video', { direction: 'recvonly' });
       const offer = await pc.createOffer();


### PR DESCRIPTION
## Summary
- handle WebRTC `ontrack` events without streams to display video

## Testing
- `pytest` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dd9d2a248321819181b10bd2cdfc