### PR TITLE
refactor: apply glass UI and remove wallpaper

### DIFF
--- a/webapp/frontend/alpr.css
+++ b/webapp/frontend/alpr.css
@@ -1,15 +1,17 @@
 
 #alpr-demo {
-  background-color: rgba(31, 41, 55, 0.8);
+  background-color: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(10px);
+  color: #001f3f;
   padding: 20px;
   border-radius: 8px;
   margin-top: 20px;
 }
 
 #alpr-form input[type="file"] {
-  background-color: #374151;
-  color: white;
-  border: 1px solid #4b5563;
+  background-color: rgba(255, 255, 255, 0.6);
+  color: #001f3f;
+  border: 1px solid #cbd5e1;
   border-radius: 4px;
   padding: 8px;
 }
@@ -29,9 +31,9 @@
 }
 
 #alpr-stream-form input[type="text"] {
-  background-color: #374151;
-  color: white;
-  border: 1px solid #4b5563;
+  background-color: rgba(255, 255, 255, 0.6);
+  color: #001f3f;
+  border: 1px solid #cbd5e1;
   border-radius: 4px;
   padding: 8px;
 }
@@ -58,10 +60,12 @@
 
 .image-box {
     width: 45%;
-    border: 2px solid #374151;
+    border: 2px solid #cbd5e1;
     border-radius: 8px;
     padding: 10px;
-    background-color: #1f2937;
+    background-color: rgba(255, 255, 255, 0.6);
+    backdrop-filter: blur(10px);
+    color: #001f3f;
 }
 
 #stream-box {
@@ -70,12 +74,12 @@
 
 #alpr-uploaded-image, #alpr-result {
   margin-top: 20px;
-  border: 2px solid #374151;
+  border: 2px solid #cbd5e1;
   border-radius: 8px;
 }
 
 #alpr-stream {
   margin-top: 20px;
-  border: 2px solid #374151;
+  border: 2px solid #cbd5e1;
   border-radius: 8px;
 }

--- a/webapp/frontend/alpr.html
+++ b/webapp/frontend/alpr.html
@@ -9,15 +9,11 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <video autoplay muted loop id="bg-video">
-    <source src="static/mylivewallpapers.mp4" type="video/mp4">
-  </video>
   <div class="layout">
-    <div class="sidebar">
-      <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
+    <div class="sidebar glass">
       <a href="index.html#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
-        <h1 class="text-2xl font-bold text-white">TonAI</h1>
+        <h1 class="text-2xl font-bold">TonAI</h1>
       </a>
       <a href="index.html#/home" id="home-link"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="index.html#/projects" id="projects-link" class="active"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
@@ -27,7 +23,7 @@
         <button id="logout-btn" class="login-btn">Logout</button>
       </div>
     </div>
-    <div class="main-content">
+    <div class="main-content glass">
       <h1 class="text-5xl font-bold mb-10 text-center title">License Plate Recognition</h1>
       <div class="project-cards">
         <a href="alpr_upload.html" class="project-card">ALPR Upload</a>

--- a/webapp/frontend/alpr_stream.html
+++ b/webapp/frontend/alpr_stream.html
@@ -9,15 +9,11 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <video autoplay muted loop id="bg-video">
-    <source src="static/mylivewallpapers.mp4" type="video/mp4">
-  </video>
   <div class="layout">
-    <div class="sidebar">
-      <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
+    <div class="sidebar glass">
       <a href="index.html#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
-        <h1 class="text-2xl font-bold text-white">TonAI</h1>
+        <h1 class="text-2xl font-bold">TonAI</h1>
       </a>
       <a href="index.html#/home" id="home-link"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="index.html#/projects" id="projects-link" class="active"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
@@ -27,14 +23,14 @@
         <button id="logout-btn" class="login-btn">Logout</button>
       </div>
     </div>
-    <div class="main-content">
+    <div class="main-content glass">
       <h1 class="text-5xl font-bold mb-10 text-center title">License Plate Recognition</h1>
       <div id="alpr-demo" class="flex flex-col items-center">
-        <div class="mb-4 flex items-center" id="stream-controls">
-          <select id="camera-select" class="mb-2 p-2 rounded bg-gray-700 text-white"></select>
-          <button id="start-stream" class="bg-blue-600 text-white px-4 py-2 rounded ml-2">Start</button>
-          <button id="pause-stream" class="bg-yellow-600 text-white px-4 py-2 rounded ml-2">Pause</button>
-          <button id="stop-stream" class="bg-red-600 text-white px-4 py-2 rounded ml-2">Stop</button>
+          <div class="mb-4 flex items-center" id="stream-controls">
+            <select id="camera-select" class="mb-2 p-2 rounded glass"></select>
+            <button id="start-stream" class="bg-blue-600 text-white px-4 py-2 rounded ml-2">Start</button>
+            <button id="pause-stream" class="bg-yellow-600 text-white px-4 py-2 rounded ml-2">Pause</button>
+            <button id="stop-stream" class="bg-red-600 text-white px-4 py-2 rounded ml-2">Stop</button>
         </div>
         <div class="image-box" id="stream-box">
           <h2 class="text-2xl font-bold mb-4 text-center">Video Stream</h2>

--- a/webapp/frontend/alpr_upload.html
+++ b/webapp/frontend/alpr_upload.html
@@ -9,15 +9,11 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <video autoplay muted loop id="bg-video">
-    <source src="static/mylivewallpapers.mp4" type="video/mp4">
-  </video>
   <div class="layout">
-    <div class="sidebar">
-      <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
+    <div class="sidebar glass">
       <a href="index.html#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
-        <h1 class="text-2xl font-bold text-white">TonAI</h1>
+        <h1 class="text-2xl font-bold">TonAI</h1>
       </a>
       <a href="index.html#/home" id="home-link"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="index.html#/projects" id="projects-link" class="active"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
@@ -27,7 +23,7 @@
         <button id="logout-btn" class="login-btn">Logout</button>
       </div>
     </div>
-    <div class="main-content">
+    <div class="main-content glass">
       <h1 class="text-5xl font-bold mb-10 text-center title">License Plate Recognition - Image</h1>
       <div id="alpr-demo" class="flex flex-col items-center">
         <form id="alpr-form" class="mb-4">

--- a/webapp/frontend/index.html
+++ b/webapp/frontend/index.html
@@ -8,15 +8,11 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <video autoplay muted loop id="bg-video">
-    <source src="static/mylivewallpapers.mp4" type="video/mp4">
-  </video>
   <div class="layout">
-    <div class="sidebar">
-      <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
+    <div class="sidebar glass">
       <a href="#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
-        <h1 class="text-2xl font-bold text-white">TonAI</h1>
+        <h1 class="text-2xl font-bold">TonAI</h1>
       </a>
       <a href="#/home" id="home-link" class="active"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="#/projects" id="projects-link"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
@@ -27,7 +23,7 @@
         <button id="logout-btn" class="login-btn">Logout</button>
       </div>
     </div>
-    <div class="main-content">
+    <div class="main-content glass">
       <div id="home-page" class="flex justify-center items-center">
         <div class="content">
           <h1 class="title">TonAI Vision</h1>

--- a/webapp/frontend/login.html
+++ b/webapp/frontend/login.html
@@ -8,17 +8,14 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="flex items-center justify-center h-screen">
-  <video autoplay muted loop id="bg-video">
-    <source src="static/mylivewallpapers.mp4" type="video/mp4">
-  </video>
-  <div class="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-sm">
+  <div class="p-8 rounded-lg shadow-lg w-full max-w-sm glass">
     <div class="flex justify-center mb-6">
       <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-16 w-16">
     </div>
-    <h2 class="text-2xl font-bold text-center text-white mb-6">TonAI Vision Login</h2>
+    <h2 class="text-2xl font-bold text-center mb-6">TonAI Vision Login</h2>
     <form id="login-form" class="space-y-4">
-      <input id="username" type="text" placeholder="Username" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none" required>
-      <input id="password" type="password" placeholder="Password" class="w-full p-2 rounded bg-gray-700 text-white focus:outline-none" required>
+      <input id="username" type="text" placeholder="Username" class="w-full p-2 rounded glass focus:outline-none" required>
+      <input id="password" type="password" placeholder="Password" class="w-full p-2 rounded glass focus:outline-none" required>
       <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded">Login</button>
       <p id="login-error" class="text-red-500 text-sm text-center hidden">Invalid credentials</p>
     </form>

--- a/webapp/frontend/sidebar.js
+++ b/webapp/frontend/sidebar.js
@@ -1,15 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const toggleBtn = document.getElementById('toggle-sidebar');
-  const sidebar = document.querySelector('.sidebar');
   const userBtn = document.querySelector('.user-settings');
   const userPopup = document.getElementById('user-popup');
-
-  if (toggleBtn) {
-    toggleBtn.addEventListener('click', () => {
-      const isCollapsed = sidebar.classList.toggle('collapsed');
-      toggleBtn.innerHTML = isCollapsed ? '<i class="fas fa-chevron-right"></i>' : '<i class="fas fa-chevron-left"></i>';
-    });
-  }
 
   if (userBtn && userPopup) {
     userBtn.addEventListener('click', (e) => {

--- a/webapp/frontend/style.css
+++ b/webapp/frontend/style.css
@@ -12,9 +12,9 @@ html {
 body {
   font-family: 'Orbitron', sans-serif;
   margin: 0;
-  color: white;
+  color: #001f3f;
   height: 100vh;
-  background-color: #1f2937;
+  background-color: #f0f4f8;
 }
 
 button {
@@ -36,23 +36,9 @@ button.rounded {
   border-radius: 12px;
 }
 
-#bg-video {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  z-index: -1;
-}
-
-.toggle-btn {
-  background-color: transparent;
-  color: white;
-  border: none;
-  padding: 10px;
-  border-radius: 12px;
-  cursor: pointer;
+.glass {
+  background: rgba(255, 255, 255, 0.6);
+  backdrop-filter: blur(10px);
 }
 
 .top-bar {
@@ -80,28 +66,21 @@ button.rounded {
 
 .sidebar {
   width: 200px;
-  background-color: rgba(31, 41, 55, 0.8);
   padding: 20px;
   flex-shrink: 0; /* Prevent sidebar from shrinking */
   position: fixed;
   left: 0;
   top: 0;
   bottom: 0;
-  transition: width 0.3s;
   display: flex;
   flex-direction: column;
   z-index: 10;
 }
 
-/* Collapsed state shows only icons but keeps enough space for images */
-.sidebar.collapsed {
-  width: 100px; /* enough width for logo and avatar */
-}
-
 .sidebar a {
   display: flex;
   align-items: center;
-  color: white;
+  color: #001f3f;
   padding: 10px;
   text-decoration: none;
   border-radius: 5px;
@@ -109,22 +88,8 @@ button.rounded {
   gap: 10px;
 }
 
-.sidebar.collapsed a {
-  justify-content: center;
-}
-
-.sidebar.collapsed .link-text,
-.sidebar.collapsed h1 {
-  display: none;
-}
-
-.sidebar.collapsed #logo-link img,
-.sidebar.collapsed .user-settings img {
-  margin-right: 0;
-}
-
 .sidebar a.active, .sidebar a:hover {
-  background-color: #374151;
+  background-color: rgba(255, 255, 255, 0.3);
 }
 
 .user-settings {
@@ -135,7 +100,8 @@ button.rounded {
   position: absolute;
   bottom: 20px;
   left: 20px;
-  background-color: rgba(31, 41, 55, 0.95);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #001f3f;
   padding: 10px;
   border-radius: 8px;
   display: none;
@@ -152,11 +118,6 @@ button.rounded {
   overflow-y: auto; /* Allow scrolling for content that overflows */
   padding-top: 20px;
   padding-left: 220px;
-  transition: padding-left 0.3s;
-}
-
-.sidebar.collapsed + .main-content {
-    padding-left: 100px;
 }
 
 
@@ -194,14 +155,14 @@ button.rounded {
 #home-page .title {
   font-size: 6rem;
   font-weight: bold;
-  color: white;
+  color: #001f3f;
   letter-spacing: 0.1em;
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
+  text-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   transition: text-shadow 0.3s, transform 0.3s;
 }
 
 #home-page .title:hover {
-  text-shadow: 0 0 40px rgba(255, 255, 255, 0.7);
+  text-shadow: 0 0 40px rgba(0, 0, 0, 0.2);
   transform: scale(1.05);
 }
 
@@ -218,8 +179,8 @@ button.rounded {
 #projects-page .title {
   font-size: 3rem;
   font-weight: bold;
-  color: white;
-  text-shadow: 0 0 20px rgba(255, 255, 255, 0.5);
+  color: #001f3f;
+  text-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
   margin-bottom: 40px;
 }
 
@@ -235,21 +196,21 @@ button.rounded {
   justify-content: center;
   width: 300px;
   height: 180px;
-  background-color: #1f2937;
-  color: white;
-  border: 1px solid #374151;
+  background-color: rgba(255, 255, 255, 0.6);
+  color: #001f3f;
+  border: 1px solid #cbd5e1;
   border-radius: 50px;
   text-decoration: none;
   font-size: 1.5rem;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
   transition: background-color 0.3s, transform 0.2s, box-shadow 0.3s;
 }
 
 #projects-page .project-card:hover {
-  background-color: #374151;
+  background-color: rgba(255, 255, 255, 0.8);
   transform: translateY(-5px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
 }
 

--- a/webapp/frontend/video_management.html
+++ b/webapp/frontend/video_management.html
@@ -9,15 +9,11 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
-  <video autoplay muted loop id="bg-video">
-    <source src="static/mylivewallpapers.mp4" type="video/mp4">
-  </video>
   <div class="layout">
-    <div class="sidebar">
-      <button id="toggle-sidebar" class="toggle-btn"><i class="fas fa-chevron-left"></i></button>
+    <div class="sidebar glass">
       <a href="index.html#/home" id="logo-link" class="flex items-center my-4">
         <img src="static/tonai_logo.png" alt="TonAI Logo" class="h-8 w-8 mr-2">
-        <h1 class="text-2xl font-bold text-white">TonAI</h1>
+        <h1 class="text-2xl font-bold">TonAI</h1>
       </a>
       <a href="index.html#/home" id="home-link"><i class="fas fa-home"></i><span class="link-text">Home</span></a>
       <a href="index.html#/projects" id="projects-link" class="active"><i class="fas fa-project-diagram"></i><span class="link-text">Projects</span></a>
@@ -27,45 +23,45 @@
         <button id="logout-btn" class="login-btn">Logout</button>
       </div>
     </div>
-    <div class="main-content">
+    <div class="main-content glass">
       <h1 class="text-5xl font-bold mb-10 text-center title">Video Management - Preview</h1>
       <div id="video-grid" class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div class="stream-slot bg-gray-800 p-4 rounded">
-          <div class="mb-2 flex items-center">
-            <select class="camera-select p-2 rounded bg-gray-700 text-white flex-1"></select>
-            <input type="text" class="custom-url p-2 rounded bg-gray-700 text-white flex-1 ml-2 hidden" placeholder="RTSP URL" />
-            <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
-            <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+          <div class="stream-slot p-4 rounded glass">
+            <div class="mb-2 flex items-center">
+              <select class="camera-select p-2 rounded glass flex-1"></select>
+              <input type="text" class="custom-url p-2 rounded glass flex-1 ml-2 hidden" placeholder="RTSP URL" />
+              <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
+              <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+            </div>
+            <img class="video-stream w-full rounded" />
           </div>
-          <img class="video-stream w-full rounded" />
-        </div>
-        <div class="stream-slot bg-gray-800 p-4 rounded">
-          <div class="mb-2 flex items-center">
-            <select class="camera-select p-2 rounded bg-gray-700 text-white flex-1"></select>
-            <input type="text" class="custom-url p-2 rounded bg-gray-700 text-white flex-1 ml-2 hidden" placeholder="RTSP URL" />
-            <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
-            <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+          <div class="stream-slot p-4 rounded glass">
+            <div class="mb-2 flex items-center">
+              <select class="camera-select p-2 rounded glass flex-1"></select>
+              <input type="text" class="custom-url p-2 rounded glass flex-1 ml-2 hidden" placeholder="RTSP URL" />
+              <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
+              <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+            </div>
+            <img class="video-stream w-full rounded" />
           </div>
-          <img class="video-stream w-full rounded" />
-        </div>
-        <div class="stream-slot bg-gray-800 p-4 rounded">
-          <div class="mb-2 flex items-center">
-            <select class="camera-select p-2 rounded bg-gray-700 text-white flex-1"></select>
-            <input type="text" class="custom-url p-2 rounded bg-gray-700 text-white flex-1 ml-2 hidden" placeholder="RTSP URL" />
-            <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
-            <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+          <div class="stream-slot p-4 rounded glass">
+            <div class="mb-2 flex items-center">
+              <select class="camera-select p-2 rounded glass flex-1"></select>
+              <input type="text" class="custom-url p-2 rounded glass flex-1 ml-2 hidden" placeholder="RTSP URL" />
+              <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
+              <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+            </div>
+            <img class="video-stream w-full rounded" />
           </div>
-          <img class="video-stream w-full rounded" />
-        </div>
-        <div class="stream-slot bg-gray-800 p-4 rounded">
-          <div class="mb-2 flex items-center">
-            <select class="camera-select p-2 rounded bg-gray-700 text-white flex-1"></select>
-            <input type="text" class="custom-url p-2 rounded bg-gray-700 text-white flex-1 ml-2 hidden" placeholder="RTSP URL" />
-            <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
-            <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+          <div class="stream-slot p-4 rounded glass">
+            <div class="mb-2 flex items-center">
+              <select class="camera-select p-2 rounded glass flex-1"></select>
+              <input type="text" class="custom-url p-2 rounded glass flex-1 ml-2 hidden" placeholder="RTSP URL" />
+              <button class="start-stream bg-blue-600 text-white px-2 py-2 rounded ml-2">Start</button>
+              <button class="stop-stream bg-red-600 text-white px-2 py-2 rounded ml-2">Stop</button>
+            </div>
+            <img class="video-stream w-full rounded" />
           </div>
-          <img class="video-stream w-full rounded" />
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- redesign frontend with light glass effect and navy text
- drop live wallpaper and sidebar toggle
- clean up unused styles and assets

## Testing
- `pytest` *(fails: Segmentation fault in onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_68afcdb328a88321aab41cda49bc3ee3